### PR TITLE
S-05: implement risk engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ and [`docs/TECH_DESIGN_REQUIREMENTS.md`](docs/TECH_DESIGN_REQUIREMENTS.md).
   generates a `signals.parquet` artifact with rule outcomes and rank scores.
 - `poetry run ts signals explain --config configs/sample-config.yml --symbol AAPL --as-of YYYY-MM-DD`
   prints the entry/exit evaluation details and key indicator values for a symbol.
+- `poetry run ts risk evaluate --config configs/sample-config.yml --holdings data/holdings.json --as-of YYYY-MM-DD`
+  emits `risk_alerts.json` summarizing crash/drawdown alerts and market filter state.
+- `poetry run ts risk explain --config configs/sample-config.yml --holdings data/holdings.json --symbol AAPL --as-of YYYY-MM-DD`
+  surfaces detailed metrics supporting each alert for the selected holding.
 
 ### Handy Automation Commands
 

--- a/src/trading_system/__init__.py
+++ b/src/trading_system/__init__.py
@@ -2,8 +2,17 @@
 
 from trading_system.config import Config, load_config
 from trading_system.data import run_data_pull
+from trading_system.risk import RiskEngine, load_holdings
 from trading_system.signals import StrategyEngine
 
-__all__ = ["__version__", "Config", "load_config", "run_data_pull", "StrategyEngine"]
+__all__ = [
+    "__version__",
+    "Config",
+    "load_config",
+    "run_data_pull",
+    "StrategyEngine",
+    "RiskEngine",
+    "load_holdings",
+]
 
 __version__ = "0.1.0"

--- a/src/trading_system/risk/__init__.py
+++ b/src/trading_system/risk/__init__.py
@@ -1,0 +1,376 @@
+"""Risk engine for crash/drawdown alerts and market filter evaluation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from trading_system.config import Config
+from trading_system.rules import RuleEvaluator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class Position:
+    """Position held in the portfolio."""
+
+    symbol: str
+    qty: float
+    cost_basis: float | None = None
+
+
+@dataclass(slots=True)
+class HoldingsSnapshot:
+    """Current portfolio snapshot used for risk evaluation."""
+
+    as_of_date: date | None
+    positions: tuple[Position, ...]
+    cash: float | None = None
+    base_ccy: str | None = None
+
+    @property
+    def symbols(self) -> tuple[str, ...]:
+        return tuple(position.symbol for position in self.positions)
+
+
+@dataclass(slots=True)
+class RiskAlert:
+    """Alert generated for a holding when a threshold is breached."""
+
+    symbol: str
+    alert_type: str
+    value: float
+    threshold: float
+    reason: str
+
+
+@dataclass(slots=True)
+class SymbolRiskEvaluation:
+    """Detailed metrics for a holding used in risk decisions."""
+
+    symbol: str
+    daily_return: float
+    drawdown: float
+    crash_threshold: float
+    drawdown_threshold: float
+    crash_triggered: bool
+    drawdown_triggered: bool
+    close: float | None
+    rolling_peak: float | None
+
+
+@dataclass(slots=True)
+class RiskResult:
+    """Aggregated output from a risk evaluation run."""
+
+    as_of: date
+    evaluated_at: datetime
+    market_state: str
+    alerts: tuple[RiskAlert, ...]
+    evaluations: dict[str, SymbolRiskEvaluation]
+    market_filter_pass: bool | None
+    benchmark: str | None
+    output_path: Path | None = None
+
+
+class RiskEngine:
+    """Compute crash/drawdown alerts and evaluate the market filter."""
+
+    def __init__(
+        self, config: Config, *, clock: Callable[[], datetime] | None = None
+    ) -> None:
+        self._config = config
+        self._curated_base = config.paths.data_curated
+        self._reports_base = config.paths.reports
+        self._crash_threshold = config.risk.crash_threshold_pct
+        self._drawdown_threshold = config.risk.drawdown_threshold_pct
+        self._market_filter = config.risk.market_filter
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    def evaluate(
+        self, as_of: date | str | pd.Timestamp, holdings: HoldingsSnapshot
+    ) -> RiskResult:
+        """Evaluate risk rules for the provided holdings."""
+
+        as_of_ts = _normalize_timestamp(as_of)
+        as_of_date = as_of_ts.date()
+        curated_dir = self._curated_base / as_of_ts.strftime("%Y-%m-%d")
+        if not curated_dir.is_dir():
+            raise FileNotFoundError(f"Curated data directory not found: {curated_dir}")
+
+        alerts: list[RiskAlert] = []
+        evaluations: dict[str, SymbolRiskEvaluation] = {}
+
+        for position in sorted(holdings.positions, key=lambda item: item.symbol):
+            symbol = position.symbol
+            frame = self._load_symbol_frame(curated_dir, symbol, as_of_ts)
+            if frame is None:
+                logger.warning(
+                    "Curated dataset missing for %s in %s", symbol, curated_dir
+                )
+                continue
+
+            latest = frame.iloc[-1]
+            daily_return = _safe_float(latest.get("ret_1d"))
+            crash_triggered = _is_triggered(daily_return, self._crash_threshold)
+
+            close = _safe_float(latest.get("close"))
+            rolling_peak = _safe_float(latest.get("rolling_peak"))
+            drawdown = _compute_drawdown(close, rolling_peak)
+            drawdown_triggered = _is_triggered(drawdown, self._drawdown_threshold)
+
+            if crash_triggered:
+                alerts.append(
+                    RiskAlert(
+                        symbol=symbol,
+                        alert_type="CRASH",
+                        value=daily_return,
+                        threshold=self._crash_threshold,
+                        reason=f"Daily return {daily_return:.4f} <= crash threshold {self._crash_threshold:.4f}",
+                    )
+                )
+            if drawdown_triggered:
+                alerts.append(
+                    RiskAlert(
+                        symbol=symbol,
+                        alert_type="DRAWDOWN",
+                        value=drawdown,
+                        threshold=self._drawdown_threshold,
+                        reason=f"Drawdown {drawdown:.4f} <= threshold {self._drawdown_threshold:.4f}",
+                    )
+                )
+
+            evaluations[symbol] = SymbolRiskEvaluation(
+                symbol=symbol,
+                daily_return=daily_return,
+                drawdown=drawdown,
+                crash_threshold=self._crash_threshold,
+                drawdown_threshold=self._drawdown_threshold,
+                crash_triggered=crash_triggered,
+                drawdown_triggered=drawdown_triggered,
+                close=None if math.isnan(close) else close,
+                rolling_peak=None if math.isnan(rolling_peak) else rolling_peak,
+            )
+
+        alerts.sort(key=lambda alert: (alert.symbol, alert.alert_type))
+
+        market_state, market_pass = self._evaluate_market_filter(curated_dir, as_of_ts)
+        evaluated_at = self._clock()
+
+        logger.info(
+            "Risk evaluation for %s generated %d alerts (market_state=%s)",
+            as_of_date,
+            len(alerts),
+            market_state,
+        )
+
+        return RiskResult(
+            as_of=as_of_date,
+            evaluated_at=evaluated_at,
+            market_state=market_state,
+            alerts=tuple(alerts),
+            evaluations=evaluations,
+            market_filter_pass=market_pass,
+            benchmark=(
+                self._market_filter.benchmark.upper() if self._market_filter else None
+            ),
+        )
+
+    def build(
+        self,
+        as_of: date | str | pd.Timestamp,
+        holdings: HoldingsSnapshot,
+        *,
+        dry_run: bool = False,
+    ) -> RiskResult:
+        """Evaluate risk rules and persist alerts to JSON unless ``dry_run``."""
+
+        result = self.evaluate(as_of, holdings)
+        if dry_run:
+            return result
+
+        as_of_str = result.as_of.strftime("%Y-%m-%d")
+        output_dir = self._reports_base / as_of_str
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / "risk_alerts.json"
+
+        payload = self._serialize_result(result)
+        output_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        result.output_path = output_path
+        logger.info("Risk alerts written to %s", output_path)
+        return result
+
+    def explain(
+        self,
+        symbol: str,
+        as_of: date | str | pd.Timestamp,
+        holdings: HoldingsSnapshot,
+    ) -> SymbolRiskEvaluation:
+        """Return evaluation details for ``symbol`` on ``as_of``."""
+
+        result = self.evaluate(as_of, holdings)
+        symbol_upper = symbol.upper()
+        evaluation = result.evaluations.get(symbol_upper)
+        if evaluation is None:
+            raise KeyError(f"Symbol {symbol_upper} not evaluated.")
+        return evaluation
+
+    def _load_symbol_frame(
+        self, curated_dir: Path, symbol: str, as_of: pd.Timestamp
+    ) -> pd.DataFrame | None:
+        path = curated_dir / f"{symbol.upper()}.parquet"
+        if not path.is_file():
+            return None
+        data = pd.read_parquet(path)
+        if data.empty:
+            return None
+        data["date"] = pd.to_datetime(data["date"], utc=False)
+        data = data.sort_values("date")
+        data = data[data["date"] <= as_of]
+        if data.empty:
+            return None
+        data = data.set_index("date")
+        return data
+
+    def _evaluate_market_filter(
+        self, curated_dir: Path, as_of: pd.Timestamp
+    ) -> tuple[str, bool | None]:
+        if not self._market_filter:
+            return "RISK_ON", None
+
+        benchmark_symbol = self._market_filter.benchmark.upper()
+        frame = self._load_symbol_frame(curated_dir, benchmark_symbol, as_of)
+        if frame is None:
+            logger.warning(
+                "Benchmark data missing for market filter: %s", benchmark_symbol
+            )
+            return "RISK_OFF", None
+
+        evaluator = RuleEvaluator(self._market_filter.rule)
+        series = evaluator.evaluate(frame)
+        passed = bool(series.iloc[-1]) if not series.empty else False
+        market_state = "RISK_ON" if passed else "RISK_OFF"
+        return market_state, passed
+
+    def _serialize_result(self, result: RiskResult) -> dict[str, Any]:
+        alerts_payload = [
+            {
+                "symbol": alert.symbol,
+                "type": alert.alert_type,
+                "value": alert.value,
+                "threshold": alert.threshold,
+                "reason": alert.reason,
+            }
+            for alert in result.alerts
+        ]
+
+        payload: dict[str, Any] = {
+            "date": result.as_of.isoformat(),
+            "evaluated_at": result.evaluated_at.isoformat(),
+            "market_state": result.market_state,
+            "alerts": alerts_payload,
+        }
+
+        if result.benchmark:
+            payload["market_filter"] = {
+                "benchmark": result.benchmark,
+                "passed": result.market_filter_pass,
+                "rule": self._market_filter.rule if self._market_filter else None,
+            }
+        return payload
+
+
+def load_holdings(path: str | Path) -> HoldingsSnapshot:
+    """Load a holdings snapshot from ``path``."""
+
+    holdings_path = Path(path)
+    if not holdings_path.is_file():
+        raise FileNotFoundError(f"Holdings file not found: {holdings_path}")
+
+    payload = json.loads(holdings_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("Holdings file must contain a JSON object.")
+
+    raw_positions = payload.get("positions", [])
+    if not isinstance(raw_positions, list):
+        raise ValueError("Holdings 'positions' must be a list.")
+
+    positions: list[Position] = []
+    for raw in raw_positions:
+        if not isinstance(raw, Mapping):
+            raise ValueError("Each position must be an object.")
+        symbol_raw = str(raw.get("symbol", "")).strip()
+        if not symbol_raw:
+            raise ValueError("Position missing symbol.")
+        qty = float(raw.get("qty", 0.0))
+        cost_basis = raw.get("cost_basis")
+        cost = float(cost_basis) if cost_basis is not None else None
+        positions.append(Position(symbol=symbol_raw.upper(), qty=qty, cost_basis=cost))
+
+    positions.sort(key=lambda item: item.symbol)
+
+    as_of_raw = payload.get("as_of_date")
+    as_of_date = date.fromisoformat(as_of_raw) if as_of_raw else None
+
+    cash_raw = payload.get("cash")
+    cash = float(cash_raw) if cash_raw is not None else None
+
+    base_ccy_raw = payload.get("base_ccy")
+    base_ccy = str(base_ccy_raw) if base_ccy_raw is not None else None
+
+    return HoldingsSnapshot(
+        as_of_date=as_of_date,
+        positions=tuple(positions),
+        cash=cash,
+        base_ccy=base_ccy,
+    )
+
+
+def _normalize_timestamp(value: date | str | pd.Timestamp) -> pd.Timestamp:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is not None:
+        timestamp = timestamp.tz_convert(None)
+    return timestamp.normalize()
+
+
+def _safe_float(value: Any) -> float:
+    if value is None:
+        return math.nan
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def _compute_drawdown(close: float, peak: float) -> float:
+    if math.isnan(close) or math.isnan(peak) or peak == 0:
+        return math.nan
+    return close / peak - 1.0
+
+
+def _is_triggered(value: float, threshold: float) -> bool:
+    if math.isnan(value):
+        return False
+    return value <= threshold
+
+
+__all__ = [
+    "HoldingsSnapshot",
+    "Position",
+    "RiskAlert",
+    "RiskEngine",
+    "RiskResult",
+    "SymbolRiskEvaluation",
+    "load_holdings",
+]

--- a/src/trading_system/rules.py
+++ b/src/trading_system/rules.py
@@ -1,0 +1,193 @@
+"""Reusable expression evaluator for declarative trading rules."""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from typing import Any
+
+import pandas as pd
+
+
+class RuleEvaluator:
+    """Evaluate declarative expressions against pandas DataFrames."""
+
+    _BOOL_OPS: Mapping[type[ast.boolop], str] = {
+        ast.And: "&",
+        ast.Or: "|",
+    }
+
+    _BIN_OPS: Mapping[type[ast.operator], str] = {
+        ast.Add: "+",
+        ast.Sub: "-",
+        ast.Mult: "*",
+        ast.Div: "/",
+        ast.Mod: "%",
+        ast.Pow: "**",
+    }
+
+    _CMP_OPS: Mapping[type[ast.cmpop], str] = {
+        ast.Eq: "==",
+        ast.NotEq: "!=",
+        ast.Lt: "<",
+        ast.LtE: "<=",
+        ast.Gt: ">",
+        ast.GtE: ">=",
+    }
+
+    def __init__(self, expression: str) -> None:
+        expression = expression.strip()
+        if not expression:
+            raise ValueError("Rule expression cannot be empty.")
+        self._expression = expression
+        try:
+            tree = ast.parse(expression, mode="eval")
+        except SyntaxError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Invalid rule expression: {expression!r}") from exc
+        self._tree = tree
+        self._validate(tree.body)
+
+    @property
+    def expression(self) -> str:
+        """Return the original expression string."""
+
+        return self._expression
+
+    def evaluate(self, frame: pd.DataFrame) -> pd.Series:
+        """Return a boolean series evaluating ``expression`` on ``frame``."""
+
+        if frame.empty:
+            return pd.Series(dtype="bool")
+        index = frame.index
+        context: dict[str, Any] = {column: frame[column] for column in frame.columns}
+        result = self._eval_node(self._tree.body, context, index)
+        series = _ensure_series(result, index)
+        return series.astype(bool)
+
+    def _eval_node(
+        self, node: ast.AST, context: Mapping[str, Any], index: pd.Index
+    ) -> Any:
+        if isinstance(node, ast.BoolOp):
+            op_symbol = self._BOOL_OPS[type(node.op)]
+            result = _ensure_series(
+                self._eval_node(node.values[0], context, index), index
+            )
+            for value_node in node.values[1:]:
+                operand = _ensure_series(
+                    self._eval_node(value_node, context, index), index
+                )
+                if op_symbol == "&":
+                    result = result & operand
+                else:
+                    result = result | operand
+            return result
+        if isinstance(node, ast.BinOp):
+            left = _ensure_series(self._eval_node(node.left, context, index), index)
+            right = _ensure_series(self._eval_node(node.right, context, index), index)
+            operator_symbol = self._BIN_OPS.get(type(node.op))
+            if operator_symbol is None:
+                raise ValueError(
+                    f"Unsupported operator in expression: {ast.dump(node.op)}"
+                )
+            return _apply_operator(operator_symbol, left, right)
+        if isinstance(node, ast.UnaryOp):
+            operand = _ensure_series(
+                self._eval_node(node.operand, context, index), index
+            )
+            if isinstance(node.op, ast.UAdd):
+                return operand
+            if isinstance(node.op, ast.USub):
+                return -operand
+            if isinstance(node.op, ast.Not):
+                return ~operand.astype(bool)
+            raise ValueError(f"Unsupported unary operator: {ast.dump(node.op)}")
+        if isinstance(node, ast.Compare):
+            left = _ensure_series(self._eval_node(node.left, context, index), index)
+            result = pd.Series(True, index=index)
+            for op, comparator in zip(node.ops, node.comparators, strict=False):
+                operator_symbol = self._CMP_OPS.get(type(op))
+                if operator_symbol is None:
+                    raise ValueError(f"Unsupported comparator: {ast.dump(op)}")
+                right = _ensure_series(
+                    self._eval_node(comparator, context, index), index
+                )
+                comparison = _apply_operator(operator_symbol, left, right)
+                result = result & comparison
+                left = right
+            return result
+        if isinstance(node, ast.Name):
+            if node.id not in context:
+                raise ValueError(f"Unknown identifier in expression: {node.id}")
+            return context[node.id]
+        if isinstance(node, ast.Constant):
+            return node.value
+        raise ValueError(f"Unsupported expression segment: {ast.dump(node)}")
+
+    def _validate(self, node: ast.AST) -> None:
+        if isinstance(node, ast.BoolOp):
+            if type(node.op) not in self._BOOL_OPS:
+                raise ValueError(f"Unsupported boolean operator: {ast.dump(node.op)}")
+            for value in node.values:
+                self._validate(value)
+            return
+        if isinstance(node, ast.BinOp):
+            if type(node.op) not in self._BIN_OPS:
+                raise ValueError(f"Unsupported binary operator: {ast.dump(node.op)}")
+            self._validate(node.left)
+            self._validate(node.right)
+            return
+        if isinstance(node, ast.UnaryOp):
+            if not isinstance(node.op, ast.UAdd | ast.USub | ast.Not):
+                raise ValueError(f"Unsupported unary operator: {ast.dump(node.op)}")
+            self._validate(node.operand)
+            return
+        if isinstance(node, ast.Compare):
+            for comparator in node.comparators:
+                self._validate(comparator)
+            self._validate(node.left)
+            return
+        if isinstance(node, ast.Name | ast.Constant):
+            return
+        raise ValueError(f"Unsupported node in expression: {ast.dump(node)}")
+
+
+def _apply_operator(symbol: str, left: Any, right: Any) -> Any:
+    if symbol == "+":
+        return left + right
+    if symbol == "-":
+        return left - right
+    if symbol == "*":
+        return left * right
+    if symbol == "/":
+        return left / right
+    if symbol == "%":
+        return left % right
+    if symbol == "**":
+        return left**right
+    if symbol == "==":
+        return left == right
+    if symbol == "!=":
+        return left != right
+    if symbol == "<":
+        return left < right
+    if symbol == "<=":
+        return left <= right
+    if symbol == ">":
+        return left > right
+    if symbol == ">=":
+        return left >= right
+    raise ValueError(f"Unsupported operator: {symbol}")
+
+
+def _ensure_series(value: Any, index: pd.Index) -> pd.Series:
+    if isinstance(value, pd.Series):
+        return value.reindex(index)
+    if isinstance(value, pd.Index):
+        values = list(value)
+    else:
+        values = [value] * len(index)
+    series: pd.Series[Any] = pd.Series(values, index=index)
+    return series
+
+
+__all__ = ["RuleEvaluator"]

--- a/src/trading_system/signals/__init__.py
+++ b/src/trading_system/signals/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import ast
 import logging
 import math
 from collections.abc import Mapping
@@ -14,6 +13,7 @@ from typing import Any
 import pandas as pd
 
 from trading_system.config import Config
+from trading_system.rules import RuleEvaluator
 
 logger = logging.getLogger(__name__)
 
@@ -43,188 +43,13 @@ class StrategyResult:
     output_path: Path | None = None
 
 
-class _RuleEvaluator:
-    """Evaluate declarative rule expressions against pandas frames."""
-
-    _BOOL_OPS: Mapping[type[ast.boolop], str] = {
-        ast.And: "&",
-        ast.Or: "|",
-    }
-
-    _BIN_OPS: Mapping[type[ast.operator], str] = {
-        ast.Add: "+",
-        ast.Sub: "-",
-        ast.Mult: "*",
-        ast.Div: "/",
-        ast.Mod: "%",
-        ast.Pow: "**",
-    }
-
-    _CMP_OPS: Mapping[type[ast.cmpop], str] = {
-        ast.Eq: "==",
-        ast.NotEq: "!=",
-        ast.Lt: "<",
-        ast.LtE: "<=",
-        ast.Gt: ">",
-        ast.GtE: ">=",
-    }
-
-    def __init__(self, expression: str) -> None:
-        expression = expression.strip()
-        if not expression:
-            raise ValueError("Rule expression cannot be empty.")
-        self._expression = expression
-        try:
-            tree = ast.parse(expression, mode="eval")
-        except SyntaxError as exc:  # pragma: no cover - defensive
-            raise ValueError(f"Invalid rule expression: {expression!r}") from exc
-        self._tree = tree
-        self._validate(tree.body)
-
-    def evaluate(self, frame: pd.DataFrame) -> pd.Series:
-        """Return a boolean series for ``expression`` evaluated on ``frame``."""
-
-        if frame.empty:
-            return pd.Series(dtype="bool")
-        index = frame.index
-        context: dict[str, Any] = {column: frame[column] for column in frame.columns}
-        result = self._eval_node(self._tree.body, context, index)
-        series = _ensure_series(result, index)
-        return series.astype(bool)
-
-    def _eval_node(
-        self, node: ast.AST, context: Mapping[str, Any], index: pd.Index
-    ) -> Any:
-        if isinstance(node, ast.BoolOp):
-            op_symbol = self._BOOL_OPS[type(node.op)]
-            result = _ensure_series(
-                self._eval_node(node.values[0], context, index), index
-            )
-            for value_node in node.values[1:]:
-                operand = _ensure_series(
-                    self._eval_node(value_node, context, index), index
-                )
-                if op_symbol == "&":
-                    result = result & operand
-                else:
-                    result = result | operand
-            return result
-        if isinstance(node, ast.BinOp):
-            left = _ensure_series(self._eval_node(node.left, context, index), index)
-            right = _ensure_series(self._eval_node(node.right, context, index), index)
-            operator_symbol = self._BIN_OPS.get(type(node.op))
-            if operator_symbol is None:
-                raise ValueError(
-                    f"Unsupported operator in expression: {ast.dump(node.op)}"
-                )
-            return _apply_operator(operator_symbol, left, right)
-        if isinstance(node, ast.UnaryOp):
-            operand = _ensure_series(
-                self._eval_node(node.operand, context, index), index
-            )
-            if isinstance(node.op, ast.UAdd):
-                return operand
-            if isinstance(node.op, ast.USub):
-                return -operand
-            if isinstance(node.op, ast.Not):
-                return ~operand.astype(bool)
-            raise ValueError(f"Unsupported unary operator: {ast.dump(node.op)}")
-        if isinstance(node, ast.Compare):
-            left = _ensure_series(self._eval_node(node.left, context, index), index)
-            result = pd.Series(True, index=index)
-            for op, comparator in zip(node.ops, node.comparators, strict=False):
-                operator_symbol = self._CMP_OPS.get(type(op))
-                if operator_symbol is None:
-                    raise ValueError(f"Unsupported comparator: {ast.dump(op)}")
-                right = _ensure_series(
-                    self._eval_node(comparator, context, index), index
-                )
-                comparison = _apply_operator(operator_symbol, left, right)
-                result = result & comparison
-                left = right
-            return result
-        if isinstance(node, ast.Name):
-            if node.id not in context:
-                raise ValueError(f"Unknown identifier in expression: {node.id}")
-            return context[node.id]
-        if isinstance(node, ast.Constant):
-            return node.value
-        raise ValueError(f"Unsupported expression segment: {ast.dump(node)}")
-
-    def _validate(self, node: ast.AST) -> None:
-        if isinstance(node, ast.BoolOp):
-            if type(node.op) not in self._BOOL_OPS:
-                raise ValueError(f"Unsupported boolean operator: {ast.dump(node.op)}")
-            for value in node.values:
-                self._validate(value)
-            return
-        if isinstance(node, ast.BinOp):
-            if type(node.op) not in self._BIN_OPS:
-                raise ValueError(f"Unsupported binary operator: {ast.dump(node.op)}")
-            self._validate(node.left)
-            self._validate(node.right)
-            return
-        if isinstance(node, ast.UnaryOp):
-            if not isinstance(node.op, ast.UAdd | ast.USub | ast.Not):
-                raise ValueError(f"Unsupported unary operator: {ast.dump(node.op)}")
-            self._validate(node.operand)
-            return
-        if isinstance(node, ast.Compare):
-            for comparator in node.comparators:
-                self._validate(comparator)
-            self._validate(node.left)
-            return
-        if isinstance(node, ast.Name | ast.Constant):
-            return
-        raise ValueError(f"Unsupported node in expression: {ast.dump(node)}")
-
-
-def _apply_operator(symbol: str, left: Any, right: Any) -> Any:
-    if symbol == "+":
-        return left + right
-    if symbol == "-":
-        return left - right
-    if symbol == "*":
-        return left * right
-    if symbol == "/":
-        return left / right
-    if symbol == "%":
-        return left % right
-    if symbol == "**":
-        return left**right
-    if symbol == "==":
-        return left == right
-    if symbol == "!=":
-        return left != right
-    if symbol == "<":
-        return left < right
-    if symbol == "<=":
-        return left <= right
-    if symbol == ">":
-        return left > right
-    if symbol == ">=":
-        return left >= right
-    raise ValueError(f"Unsupported operator: {symbol}")
-
-
-def _ensure_series(value: Any, index: pd.Index) -> pd.Series:
-    if isinstance(value, pd.Series):
-        return value.reindex(index)
-    if isinstance(value, pd.Index):
-        values = list(value)
-    else:
-        values = [value] * len(index)
-    series: pd.Series[Any] = pd.Series(values, index=index)
-    return series
-
-
 class StrategyEngine:
     """Evaluate configured strategy rules against curated inputs."""
 
     def __init__(self, config: Config) -> None:
         self._config = config
-        self._entry_evaluator = _RuleEvaluator(config.strategy.entry)
-        self._exit_evaluator = _RuleEvaluator(config.strategy.exit)
+        self._entry_evaluator = RuleEvaluator(config.strategy.entry)
+        self._exit_evaluator = RuleEvaluator(config.strategy.exit)
         self._rank_metric = config.strategy.rank or "momentum_63d"
         self._curated_base = config.paths.data_curated
         self._reports_base = config.paths.reports

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -1,0 +1,217 @@
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from typer.testing import CliRunner
+
+from trading_system.cli import app
+from trading_system.config import load_config
+from trading_system.risk import RiskEngine, load_holdings
+
+runner = CliRunner()
+
+RISK_CONFIG = """
+base_ccy: USD
+calendar: NYSE
+data:
+  provider: yahoo
+  lookback_days: 30
+universe:
+  tickers: [{tickers}]
+strategy:
+  type: trend_follow
+  entry: "close > sma_100"
+  exit: "close < sma_100"
+  rank: momentum_63d
+risk:
+  crash_threshold_pct: -0.08
+  drawdown_threshold_pct: -0.20
+  market_filter:
+    benchmark: SPY
+    rule: "close > sma_200"
+rebalance:
+  cadence: monthly
+  max_positions: 5
+notify:
+  email: ops@example.com
+paths:
+  data_raw: data/raw
+  data_curated: data/curated
+  reports: reports
+"""
+
+
+def _write_config(tmp_path: Path, tickers: list[str]) -> Path:
+    config_text = RISK_CONFIG.format(tickers=", ".join(tickers))
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(config_text, encoding="utf-8")
+    return config_path
+
+
+def _make_curated_frame(
+    dates: pd.DatetimeIndex,
+    symbol: str,
+    closes: np.ndarray,
+) -> pd.DataFrame:
+    series = pd.Series(closes, index=dates, dtype=float)
+    values = series.to_numpy(copy=True)
+    frame = pd.DataFrame(
+        {
+            "date": dates,
+            "symbol": symbol,
+            "open": values,
+            "high": values,
+            "low": values,
+            "close": values,
+            "volume": np.full(len(series), 1_000, dtype=float),
+            "adj_close": values,
+            "sma_100": series.rolling(100, min_periods=1).mean().to_numpy(),
+            "sma_200": series.rolling(200, min_periods=1).mean().to_numpy(),
+            "ret_1d": series.pct_change().fillna(0.0).to_numpy(),
+            "ret_20d": series.pct_change(20).fillna(0.0).to_numpy(),
+            "rolling_peak": series.cummax().to_numpy(),
+        }
+    )
+    return frame
+
+
+def _write_curated(
+    config_path: Path, as_of: pd.Timestamp, frames: dict[str, pd.DataFrame]
+) -> Path:
+    config = load_config(config_path)
+    curated_dir = config.paths.data_curated / as_of.strftime("%Y-%m-%d")
+    curated_dir.mkdir(parents=True, exist_ok=True)
+    for symbol, frame in frames.items():
+        frame.to_parquet(curated_dir / f"{symbol}.parquet", index=False)
+    return curated_dir
+
+
+def _write_holdings(tmp_path: Path, positions: list[dict[str, object]]) -> Path:
+    holdings_path = tmp_path / "holdings.json"
+    payload = {
+        "as_of_date": "2024-05-02",
+        "positions": positions,
+        "cash": 10000.0,
+        "base_ccy": "USD",
+    }
+    holdings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return holdings_path
+
+
+def test_risk_engine_generates_alerts_and_json(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, ["AAPL", "MSFT", "SPY"])
+    as_of = pd.Timestamp("2024-05-02")
+    dates = pd.bdate_range(end=as_of, periods=10)
+
+    aapl_closes = np.array([100, 105, 110, 108, 102, 97, 95, 90, 88, 80], dtype=float)
+    msft_closes = np.array([50, 51, 52, 53, 54, 55, 56, 57, 58, 59], dtype=float)
+    spy_closes = np.array(
+        [400, 401, 402, 399, 398, 397, 396, 395, 394, 393], dtype=float
+    )
+
+    aapl_frame = _make_curated_frame(dates, "AAPL", aapl_closes)
+    msft_frame = _make_curated_frame(dates, "MSFT", msft_closes)
+    spy_frame = _make_curated_frame(dates, "SPY", spy_closes)
+    spy_frame["sma_200"] = 405.0  # ensure market filter fails
+
+    _write_curated(
+        config_path,
+        as_of,
+        {"AAPL": aapl_frame, "MSFT": msft_frame, "SPY": spy_frame},
+    )
+
+    holdings_path = _write_holdings(
+        tmp_path,
+        [
+            {"symbol": "AAPL", "qty": 10, "cost_basis": 120.0},
+            {"symbol": "MSFT", "qty": 5, "cost_basis": 45.0},
+        ],
+    )
+
+    config = load_config(config_path)
+    holdings = load_holdings(holdings_path)
+
+    def fixed_clock() -> datetime:
+        return datetime(2024, 5, 2, 22, tzinfo=UTC)
+
+    engine = RiskEngine(config, clock=fixed_clock)
+
+    result = engine.build(as_of, holdings, dry_run=False)
+
+    assert result.market_state == "RISK_OFF"
+    assert result.output_path is not None
+    assert result.output_path.exists()
+
+    alerts = {(alert.symbol, alert.alert_type) for alert in result.alerts}
+    assert ("AAPL", "CRASH") in alerts
+    assert ("AAPL", "DRAWDOWN") in alerts
+
+    payload = json.loads(result.output_path.read_text(encoding="utf-8"))
+    assert payload["market_state"] == "RISK_OFF"
+    assert len(payload["alerts"]) == 2
+    assert payload["alerts"][0]["symbol"] == "AAPL"
+
+    aapl_eval = result.evaluations["AAPL"]
+    assert aapl_eval.crash_triggered is True
+    assert aapl_eval.drawdown_triggered is True
+    assert aapl_eval.drawdown <= -0.2
+
+
+def test_risk_cli_commands_run(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, ["AAPL", "SPY"])
+    as_of = pd.Timestamp("2024-05-02")
+    dates = pd.bdate_range(end=as_of, periods=6)
+
+    aapl_closes = np.array([90, 92, 91, 85, 83, 75], dtype=float)
+    spy_closes = np.array([300, 299, 298, 297, 296, 295], dtype=float)
+
+    aapl_frame = _make_curated_frame(dates, "AAPL", aapl_closes)
+    spy_frame = _make_curated_frame(dates, "SPY", spy_closes)
+    spy_frame["sma_200"] = 305.0
+
+    _write_curated(config_path, as_of, {"AAPL": aapl_frame, "SPY": spy_frame})
+
+    holdings_path = _write_holdings(
+        tmp_path, [{"symbol": "AAPL", "qty": 12, "cost_basis": 95.0}]
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "risk",
+            "evaluate",
+            "--config",
+            str(config_path),
+            "--holdings",
+            str(holdings_path),
+            "--as-of",
+            "2024-05-02",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Risk alerts written" in result.stdout
+
+    alerts_path = tmp_path / "reports" / "2024-05-02" / "risk_alerts.json"
+    assert alerts_path.exists()
+
+    explain = runner.invoke(
+        app,
+        [
+            "risk",
+            "explain",
+            "--config",
+            str(config_path),
+            "--holdings",
+            str(holdings_path),
+            "--symbol",
+            "AAPL",
+            "--as-of",
+            "2024-05-02",
+        ],
+    )
+
+    assert explain.exit_code == 0
+    assert "daily_return" in explain.stdout


### PR DESCRIPTION
## Story
- [S-05](docs/stories/S-05.md)

## Summary
- extracted the declarative rule evaluator into `trading_system.rules` so signals and risk share the same DSL
- implemented a deterministic `RiskEngine` with holdings loader, alert serialization, and market filter evaluation plus unit tests
- added CLI commands for `ts risk evaluate/explain` and documented the workflow in the README

## Testing
- `poetry run fmt`
- `poetry run lint`
- `poetry run typecheck`
- `poetry run pytest`

## Manual Validation
```
$ poetry run ts risk evaluate --config configs/sample-config.yml --holdings data/holdings.json --as-of 2024-05-02
Evaluated risk for 2024-05-02 — alerts: 1
Market state: RISK_OFF
Market filter [SPY] status: FAIL
┏━━━━━━━━┳━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ symbol ┃ type  ┃ value     ┃ threshold ┃
┡━━━━━━━━╇━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│ AAPL   │ CRASH │ -0.096386 │ -0.08     │
└────────┴───────┴───────────┴───────────┘
Risk alerts written to: /workspace/trading-system/configs/reports/2024-05-02/risk_alerts.json

$ poetry run ts risk explain --config configs/sample-config.yml --holdings data/holdings.json --symbol AAPL --as-of 2024-05-02
AAPL on 2024-05-02: crash_triggered=True | drawdown_triggered=False
┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ metric             ┃ value     ┃
┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
│ daily_return       │ -0.096386 │
│ crash_threshold    │ -0.08     │
│ drawdown           │ -0.184783 │
│ drawdown_threshold │ -0.2      │
│ close              │ 75        │
│ rolling_peak       │ 92        │
└────────────────────┴───────────┘
```

## Checklist
- [x] TECH_DESIGN_REQUIREMENTS.md compliance
- [x] WORKFLOW.md compliance

------
https://chatgpt.com/codex/tasks/task_e_68cf9d55decc83209bafad8a435ae470