### PR TITLE
S-06: implement rebalancer module

### DIFF
--- a/src/trading_system/__init__.py
+++ b/src/trading_system/__init__.py
@@ -3,6 +3,7 @@
 from trading_system.config import Config, load_config
 from trading_system.data import run_data_pull
 from trading_system.risk import RiskEngine, load_holdings
+from trading_system.rebalance import RebalanceEngine
 from trading_system.signals import StrategyEngine
 
 __all__ = [
@@ -12,6 +13,7 @@ __all__ = [
     "run_data_pull",
     "StrategyEngine",
     "RiskEngine",
+    "RebalanceEngine",
     "load_holdings",
 ]
 

--- a/src/trading_system/__init__.py
+++ b/src/trading_system/__init__.py
@@ -2,8 +2,8 @@
 
 from trading_system.config import Config, load_config
 from trading_system.data import run_data_pull
-from trading_system.risk import RiskEngine, load_holdings
 from trading_system.rebalance import RebalanceEngine
+from trading_system.risk import RiskEngine, load_holdings
 from trading_system.signals import StrategyEngine
 
 __all__ = [

--- a/src/trading_system/cli.py
+++ b/src/trading_system/cli.py
@@ -582,7 +582,7 @@ def rebalance_propose(
         help="Holdings snapshot JSON file.",
     ),
     as_of: str = typer.Option(..., help="As-of date for rebalance (YYYY-MM-DD)."),
-    signals_path: Path | None = typer.Option(
+    signals_path: Path | None = typer.Option(  # noqa: B008 - CLI option definition
         None,
         "--signals",
         help="Optional path to signals parquet (defaults to reports/<as_of>/signals.parquet).",
@@ -634,7 +634,7 @@ def rebalance_dry_run(
         help="Holdings snapshot JSON file.",
     ),
     as_of: str = typer.Option(..., help="As-of date for rebalance (YYYY-MM-DD)."),
-    signals_path: Path | None = typer.Option(
+    signals_path: Path | None = typer.Option(  # noqa: B008 - CLI option definition
         None,
         "--signals",
         help="Optional path to signals parquet (defaults to reports/<as_of>/signals.parquet).",

--- a/src/trading_system/cli.py
+++ b/src/trading_system/cli.py
@@ -10,6 +10,7 @@ from datetime import date
 from numbers import Real
 from pathlib import Path
 
+import pandas as pd
 import typer
 from pydantic import ValidationError
 from rich.console import Console
@@ -19,6 +20,7 @@ from trading_system.config import Config, load_config
 from trading_system.data import DataProvider, YahooDataProvider, run_data_pull
 from trading_system.data.storage import DataRunMeta
 from trading_system.preprocess import Preprocessor, PreprocessResult
+from trading_system.rebalance import RebalanceEngine, RebalanceResult
 from trading_system.risk import RiskEngine, load_holdings
 from trading_system.signals import StrategyEngine
 
@@ -26,10 +28,12 @@ app = typer.Typer(help="Utilities for research, reporting, and operations.")
 config_app = typer.Typer(help="Configuration management commands.")
 data_app = typer.Typer(help="Raw data acquisition commands.")
 signals_app = typer.Typer(help="Strategy signal evaluation commands.")
+rebalance_app = typer.Typer(help="Rebalance proposal commands.")
 risk_app = typer.Typer(help="Risk evaluation commands.")
 app.add_typer(config_app, name="config")
 app.add_typer(data_app, name="data")
 app.add_typer(signals_app, name="signals")
+app.add_typer(rebalance_app, name="rebalance")
 app.add_typer(risk_app, name="risk")
 console = Console()
 
@@ -247,6 +251,73 @@ def _format_number(value: object) -> str:
     if math.isnan(number) or math.isinf(number):
         return str(number)
     return f"{number:.6f}".rstrip("0").rstrip(".")
+
+
+def _load_signals_for_cli(
+    config: Config, signals_path: Path | None, as_of_date: date
+) -> pd.DataFrame:
+    if signals_path is None:
+        signals_path = (
+            config.paths.reports / as_of_date.strftime("%Y-%m-%d") / "signals.parquet"
+        )
+    resolved = Path(signals_path)
+    if not resolved.is_file():
+        console.print(f"[red]Signals file not found:[/] {resolved}")
+        raise typer.Exit(code=1)
+    try:
+        frame = pd.read_parquet(resolved)
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Unable to read signals parquet:[/] {exc}")
+        raise typer.Exit(code=1) from exc
+    return frame
+
+
+def _print_rebalance_summary(
+    result: RebalanceResult, *, max_targets: int | None = None
+) -> None:
+    console.print(f"[bold]{result.status}[/bold] for {result.as_of}")
+    console.print(
+        f"Turnover: {_format_number(result.turnover)} | Cash buffer: {_format_number(result.cash_buffer)}"
+    )
+
+    if result.targets:
+        target_table = Table("symbol", "target_weight", "rationale")
+        targets = list(result.targets)
+        if max_targets is not None and max_targets >= 0:
+            subset = targets[:max_targets]
+        else:
+            subset = targets
+        for target in subset:
+            target_table.add_row(
+                target.symbol,
+                _format_number(target.target_weight),
+                target.rationale or "—",
+            )
+        console.print(target_table)
+        if max_targets is not None and max_targets >= 0 and len(targets) > max_targets:
+            console.print(
+                f"[yellow]… {len(targets) - max_targets} additional targets omitted[/yellow]"
+            )
+    else:
+        console.print("[yellow]No targets proposed.[/yellow]")
+
+    if result.orders:
+        order_table = Table("symbol", "side", "quantity", "notional")
+        for order in result.orders:
+            order_table.add_row(
+                order.symbol,
+                order.side,
+                _format_number(order.quantity),
+                _format_number(order.notional),
+            )
+        console.print(order_table)
+    else:
+        console.print("[yellow]No orders generated.[/yellow]")
+
+    if result.notes:
+        console.print("Notes:")
+        for note in result.notes:
+            console.print(f"  • {note}")
 
 
 @data_app.command("inspect")
@@ -487,6 +558,113 @@ def signals_explain(
         for name, value in sorted(evaluation.indicators.items()):
             indicator_table.add_row(name, _format_number(value))
         console.print(indicator_table)
+
+
+@rebalance_app.command("propose")
+def rebalance_propose(
+    config_path: Path = typer.Option(  # noqa: B008 - CLI option definition
+        ...,
+        "--config",
+        "--config-path",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Config file to load.",
+    ),
+    holdings_path: Path = typer.Option(  # noqa: B008 - CLI option definition
+        ...,
+        "--holdings",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Holdings snapshot JSON file.",
+    ),
+    as_of: str = typer.Option(..., help="As-of date for rebalance (YYYY-MM-DD)."),
+    signals_path: Path | None = typer.Option(
+        None,
+        "--signals",
+        help="Optional path to signals parquet (defaults to reports/<as_of>/signals.parquet).",
+    ),
+) -> None:
+    """Build a rebalance proposal and persist the resulting JSON artifact."""
+
+    config = load_config(config_path)
+    as_of_date = _parse_as_of(as_of)
+    holdings = load_holdings(holdings_path)
+    signals_frame = _load_signals_for_cli(config, signals_path, as_of_date)
+    engine = RebalanceEngine(config)
+
+    try:
+        result = engine.build(
+            as_of_date,
+            holdings=holdings,
+            signals=signals_frame,
+            dry_run=False,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Rebalance proposal failed:[/] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    _print_rebalance_summary(result)
+    if result.output_path:
+        console.print(f"Proposal written to: {result.output_path}")
+
+
+@rebalance_app.command("dry-run")
+def rebalance_dry_run(
+    config_path: Path = typer.Option(  # noqa: B008 - CLI option definition
+        ...,
+        "--config",
+        "--config-path",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Config file to load.",
+    ),
+    holdings_path: Path = typer.Option(  # noqa: B008 - CLI option definition
+        ...,
+        "--holdings",
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        help="Holdings snapshot JSON file.",
+    ),
+    as_of: str = typer.Option(..., help="As-of date for rebalance (YYYY-MM-DD)."),
+    signals_path: Path | None = typer.Option(
+        None,
+        "--signals",
+        help="Optional path to signals parquet (defaults to reports/<as_of>/signals.parquet).",
+    ),
+    max_candidates: int | None = typer.Option(
+        10,
+        help="Maximum targets to display in summary (set to 0 to hide targets).",
+    ),
+) -> None:
+    """Evaluate rebalance logic without writing artifacts."""
+
+    config = load_config(config_path)
+    as_of_date = _parse_as_of(as_of)
+    holdings = load_holdings(holdings_path)
+    signals_frame = _load_signals_for_cli(config, signals_path, as_of_date)
+    engine = RebalanceEngine(config)
+
+    try:
+        result = engine.build(
+            as_of_date,
+            holdings=holdings,
+            signals=signals_frame,
+            dry_run=True,
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Rebalance dry run failed:[/] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    limit = None if max_candidates is None or max_candidates < 0 else max_candidates
+    _print_rebalance_summary(result, max_targets=limit)
 
 
 @risk_app.command("evaluate")

--- a/src/trading_system/rebalance/__init__.py
+++ b/src/trading_system/rebalance/__init__.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import json
 import logging
 import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Mapping, Sequence
 
 import pandas as pd
 
@@ -477,9 +477,8 @@ def _orders_and_turnover(
         price = price_map.get(symbol)
         if price is None:
             continue
-        current_qty = (
-            current_positions.get(symbol).qty if symbol in current_positions else 0.0
-        )
+        current_position = current_positions.get(symbol)
+        current_qty = current_position.qty if current_position is not None else 0.0
         current_weight = current_values.get(symbol, 0.0) / total_value
         target_weight = target_weights.get(symbol, 0.0)
         turnover += abs(target_weight - current_weight)

--- a/src/trading_system/rebalance/__init__.py
+++ b/src/trading_system/rebalance/__init__.py
@@ -1,0 +1,624 @@
+"""Portfolio rebalancer converting signals into target weights and orders."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pandas as pd
+
+from trading_system.config import Config
+from trading_system.risk import HoldingsSnapshot, Position
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class RebalanceTarget:
+    """Desired allocation for a given symbol."""
+
+    symbol: str
+    target_weight: float
+    rationale: str | None = None
+
+
+@dataclass(slots=True)
+class RebalanceOrder:
+    """Order intent derived from target weights."""
+
+    symbol: str
+    side: str
+    quantity: float
+    notional: float
+
+
+@dataclass(slots=True)
+class RebalanceResult:
+    """Result returned by :class:`RebalanceEngine`."""
+
+    as_of: date
+    status: str
+    cash_buffer: float
+    turnover: float
+    targets: tuple[RebalanceTarget, ...]
+    orders: tuple[RebalanceOrder, ...]
+    notes: tuple[str, ...]
+    output_path: Path | None = None
+
+
+@dataclass(slots=True)
+class _Candidate:
+    symbol: str
+    signal: str
+    rank_score: float
+    price: float
+    rationale: str
+    is_existing: bool
+
+
+class RebalanceEngine:
+    """Construct rebalance proposals based on signals and holdings."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._curated_base = config.paths.data_curated
+        self._reports_base = config.paths.reports
+        cadence_raw = (config.rebalance.cadence or "").strip().lower()
+        if not cadence_raw:
+            raise ValueError("Rebalance cadence must be configured")
+        self._cadence = cadence_raw
+        self._max_positions = int(config.rebalance.max_positions)
+        self._equal_weight = (
+            True
+            if config.rebalance.equal_weight is None
+            else bool(config.rebalance.equal_weight)
+        )
+        self._min_weight = float(config.rebalance.min_weight or 0.0)
+        self._cash_buffer = float(config.rebalance.cash_buffer or 0.0)
+        self._turnover_cap = (
+            float(config.rebalance.turnover_cap_pct)
+            if config.rebalance.turnover_cap_pct is not None
+            else None
+        )
+
+    def evaluate(
+        self,
+        as_of: date | str | pd.Timestamp,
+        *,
+        holdings: HoldingsSnapshot,
+        signals: pd.DataFrame,
+    ) -> RebalanceResult:
+        """Evaluate rebalance logic for ``as_of`` without writing artifacts."""
+
+        as_of_ts = _normalize_timestamp(as_of)
+        as_of_date = as_of_ts.date()
+        notes: list[str] = []
+
+        if not _is_rebalance_day(as_of_ts, self._cadence):
+            notes.append(f"Cadence {self._cadence} not met on {as_of_date}")
+            return RebalanceResult(
+                as_of=as_of_date,
+                status="NO_REBALANCE",
+                cash_buffer=self._cash_buffer,
+                turnover=0.0,
+                targets=(),
+                orders=(),
+                notes=tuple(notes),
+            )
+
+        curated_dir = self._curated_base / as_of_ts.strftime("%Y-%m-%d")
+        if not curated_dir.is_dir():
+            raise FileNotFoundError(f"Curated data directory not found: {curated_dir}")
+
+        frame = _prepare_signals(signals, as_of_ts)
+        if frame.empty:
+            notes.append("No signals available for rebalance date")
+            return RebalanceResult(
+                as_of=as_of_date,
+                status="NO_CANDIDATES",
+                cash_buffer=self._cash_buffer,
+                turnover=0.0,
+                targets=(),
+                orders=(),
+                notes=tuple(notes),
+            )
+
+        current_positions: dict[str, Position] = {
+            position.symbol: position for position in holdings.positions
+        }
+
+        price_map = _load_price_map(
+            curated_dir,
+            symbols=sorted(set(frame["symbol"].unique()) | set(current_positions)),
+            as_of=as_of_ts,
+        )
+
+        candidates = _collect_candidates(
+            frame, current_positions, price_map, equal_weight=self._equal_weight
+        )
+        exit_symbols = _collect_exit_symbols(frame, current_positions)
+
+        available_weight = max(0.0, 1.0 - self._cash_buffer)
+        max_allowed = _max_positions_by_min_weight(
+            available_weight, self._min_weight, self._max_positions
+        )
+        if max_allowed == 0:
+            notes.append(
+                "Cash buffer and min_weight configuration leave no capacity for targets"
+            )
+            orders = _exit_orders(exit_symbols, current_positions, price_map)
+            return RebalanceResult(
+                as_of=as_of_date,
+                status="NO_CAPACITY",
+                cash_buffer=self._cash_buffer,
+                turnover=0.0,
+                targets=(),
+                orders=orders,
+                notes=tuple(notes),
+            )
+
+        selected = candidates[:max_allowed]
+        selected = _enforce_min_weight(
+            selected, available_weight, self._min_weight, notes
+        )
+
+        proposal = _build_proposal(
+            selected=selected,
+            exit_symbols=exit_symbols,
+            current_positions=current_positions,
+            holdings_cash=holdings.cash or 0.0,
+            price_map=price_map,
+            available_weight=available_weight,
+            equal_weight=self._equal_weight,
+        )
+
+        if self._turnover_cap is not None and proposal.turnover > self._turnover_cap:
+            proposal = _reduce_turnover(
+                selected,
+                exit_symbols,
+                current_positions,
+                holdings.cash or 0.0,
+                price_map,
+                available_weight,
+                equal_weight=self._equal_weight,
+                cap=self._turnover_cap,
+                notes=notes,
+            )
+
+        combined_notes = tuple(notes + list(proposal.notes))
+        return RebalanceResult(
+            as_of=as_of_date,
+            status=proposal.status,
+            cash_buffer=self._cash_buffer,
+            turnover=proposal.turnover,
+            targets=tuple(proposal.targets),
+            orders=tuple(proposal.orders),
+            notes=combined_notes,
+        )
+
+    def build(
+        self,
+        as_of: date | str | pd.Timestamp,
+        *,
+        holdings: HoldingsSnapshot,
+        signals: pd.DataFrame,
+        dry_run: bool = False,
+    ) -> RebalanceResult:
+        """Evaluate rebalance and persist proposal unless ``dry_run``."""
+
+        result = self.evaluate(as_of, holdings=holdings, signals=signals)
+        if dry_run:
+            return result
+
+        output_dir = self._reports_base / result.as_of.strftime("%Y-%m-%d")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / "rebalance_proposal.json"
+        payload = _serialize_result(result)
+        output_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        result.output_path = output_path
+        logger.info("Rebalance proposal written to %s", output_path)
+        return result
+
+
+@dataclass(slots=True)
+class _Proposal:
+    status: str
+    targets: list[RebalanceTarget]
+    orders: list[RebalanceOrder]
+    turnover: float
+    notes: list[str]
+
+
+def _normalize_timestamp(value: date | str | pd.Timestamp) -> pd.Timestamp:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is not None:
+        timestamp = timestamp.tz_convert(None)
+    return timestamp.normalize()
+
+
+def _is_rebalance_day(as_of: pd.Timestamp, cadence: str) -> bool:
+    if cadence == "monthly":
+        return as_of == (as_of + pd.offsets.BMonthEnd(0))
+    if cadence == "weekly":
+        return as_of.weekday() == 4  # Friday
+    raise ValueError(f"Unsupported rebalance cadence: {cadence}")
+
+
+def _prepare_signals(frame: pd.DataFrame, as_of: pd.Timestamp) -> pd.DataFrame:
+    if "symbol" not in frame.columns or "signal" not in frame.columns:
+        raise ValueError("Signals frame must contain 'symbol' and 'signal' columns")
+    working = frame.copy()
+    if "date" in working.columns:
+        working["date"] = pd.to_datetime(working["date"]).dt.normalize()
+        working = working[working["date"] == as_of]
+    working["symbol"] = working["symbol"].astype(str).str.upper()
+    if "rank_score" not in working.columns:
+        working["rank_score"] = 0.0
+    working = working.sort_values(["rank_score", "symbol"], ascending=[False, True])
+    working = working.reset_index(drop=True)
+    return working
+
+
+def _load_price_map(
+    curated_dir: Path, symbols: Sequence[str], as_of: pd.Timestamp
+) -> dict[str, float]:
+    prices: dict[str, float] = {}
+    for symbol in symbols:
+        prices[symbol] = _load_price(curated_dir, symbol, as_of)
+    return prices
+
+
+def _load_price(curated_dir: Path, symbol: str, as_of: pd.Timestamp) -> float:
+    path = curated_dir / f"{symbol}.parquet"
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Curated dataset missing for {symbol} in {curated_dir}"
+        )
+    data = pd.read_parquet(path)
+    if data.empty:
+        raise ValueError(f"Curated dataset for {symbol} is empty")
+    data["date"] = pd.to_datetime(data["date"]).dt.normalize()
+    data = data[data["date"] <= as_of]
+    if data.empty:
+        raise ValueError(f"No data for {symbol} on or before {as_of.date()}")
+    latest = data.iloc[-1]
+    price = float(latest.get("close", math.nan))
+    if math.isnan(price) or price <= 0:
+        raise ValueError(f"Invalid close price for {symbol} on {as_of.date()}")
+    return price
+
+
+def _collect_candidates(
+    frame: pd.DataFrame,
+    current_positions: Mapping[str, Position],
+    price_map: Mapping[str, float],
+    *,
+    equal_weight: bool,
+) -> list[_Candidate]:
+    candidates: list[_Candidate] = []
+    current_symbols = set(current_positions)
+    for _, row in frame.iterrows():
+        symbol = str(row["symbol"]).upper()
+        signal = str(row["signal"]).upper()
+        if signal == "EXIT":
+            continue
+        price = price_map.get(symbol)
+        if price is None:
+            continue
+        rank_score = float(row.get("rank_score", 0.0))
+        rationale = "BUY signal" if signal == "BUY" else "Maintain position"
+        if not equal_weight and rank_score <= 0 and symbol not in current_symbols:
+            # avoid allocating new positions with non-positive scores
+            continue
+        candidates.append(
+            _Candidate(
+                symbol=symbol,
+                signal=signal,
+                rank_score=rank_score,
+                price=price,
+                rationale=rationale,
+                is_existing=symbol in current_symbols,
+            )
+        )
+    candidates.sort(key=lambda item: (-item.rank_score, item.symbol))
+    return candidates
+
+
+def _collect_exit_symbols(
+    frame: pd.DataFrame, current_positions: Mapping[str, Position]
+) -> set[str]:
+    exits: set[str] = set()
+    current_symbols = set(current_positions)
+    for _, row in frame.iterrows():
+        symbol = str(row["symbol"]).upper()
+        signal = str(row["signal"]).upper()
+        if signal == "EXIT" and symbol in current_symbols:
+            exits.add(symbol)
+    return exits
+
+
+def _max_positions_by_min_weight(
+    available_weight: float, min_weight: float, max_positions: int
+) -> int:
+    if max_positions <= 0:
+        return 0
+    if min_weight <= 0:
+        return max_positions
+    allowed = int(math.floor((available_weight + 1e-9) / min_weight))
+    return max(0, min(max_positions, allowed))
+
+
+def _enforce_min_weight(
+    selected: list[_Candidate],
+    available_weight: float,
+    min_weight: float,
+    notes: list[str],
+) -> list[_Candidate]:
+    if not selected or min_weight <= 0:
+        return selected
+    while selected:
+        per_weight = available_weight / len(selected)
+        if per_weight + 1e-9 >= min_weight:
+            break
+        removed = selected.pop()
+        notes.append(f"Removed {removed.symbol} to satisfy min_weight={min_weight:.4f}")
+    return selected
+
+
+def _build_proposal(
+    *,
+    selected: Sequence[_Candidate],
+    exit_symbols: set[str],
+    current_positions: Mapping[str, Position],
+    holdings_cash: float,
+    price_map: Mapping[str, float],
+    available_weight: float,
+    equal_weight: bool,
+) -> _Proposal:
+    targets: list[RebalanceTarget] = []
+    notes: list[str] = []
+
+    if selected:
+        weights = _compute_weights(selected, available_weight, equal_weight)
+        if equal_weight:
+            allocation_mode = "equal-weight"
+        else:
+            allocation_mode = (
+                "score-weight"
+                if any(weight != weights[0] for weight in weights[1:])
+                else "equal-weight"
+            )
+        for candidate, weight in zip(selected, weights, strict=False):
+            targets.append(
+                RebalanceTarget(
+                    symbol=candidate.symbol,
+                    target_weight=weight,
+                    rationale=candidate.rationale,
+                )
+            )
+        notes.append(
+            f"Selected {len(selected)} symbols with {allocation_mode} allocation"
+        )
+    else:
+        notes.append("No candidates selected for allocation")
+
+    for symbol in sorted(exit_symbols):
+        targets.append(
+            RebalanceTarget(
+                symbol=symbol,
+                target_weight=0.0,
+                rationale="Exit signal triggered",
+            )
+        )
+
+    targets.sort(key=lambda item: (-item.target_weight, item.symbol))
+
+    orders, turnover = _orders_and_turnover(
+        current_positions=current_positions,
+        holdings_cash=holdings_cash,
+        price_map=price_map,
+        targets=targets,
+    )
+
+    status = "REBALANCE" if targets or orders else "NO_CANDIDATES"
+    return _Proposal(
+        status=status, targets=targets, orders=orders, turnover=turnover, notes=notes
+    )
+
+
+def _compute_weights(
+    selected: Sequence[_Candidate], available_weight: float, equal_weight: bool
+) -> list[float]:
+    if not selected:
+        return []
+    if equal_weight or len(selected) == 1:
+        per_weight = available_weight / len(selected)
+        return [per_weight for _ in selected]
+    scores = [max(candidate.rank_score, 0.0) for candidate in selected]
+    total_score = sum(scores)
+    if total_score <= 0:
+        per_weight = available_weight / len(selected)
+        return [per_weight for _ in selected]
+    return [available_weight * score / total_score for score in scores]
+
+
+def _orders_and_turnover(
+    *,
+    current_positions: Mapping[str, Position],
+    holdings_cash: float,
+    price_map: Mapping[str, float],
+    targets: Sequence[RebalanceTarget],
+) -> tuple[list[RebalanceOrder], float]:
+    total_value = float(holdings_cash or 0.0)
+    current_values: dict[str, float] = {}
+    for symbol, position in current_positions.items():
+        price = price_map.get(symbol)
+        if price is None:
+            raise ValueError(f"Missing price for current holding {symbol}")
+        current_values[symbol] = position.qty * price
+        total_value += current_values[symbol]
+
+    if total_value <= 0:
+        raise ValueError("Total portfolio value must be positive")
+
+    target_weights = {target.symbol: target.target_weight for target in targets}
+    orders: list[RebalanceOrder] = []
+    turnover = 0.0
+
+    symbols = sorted(set(current_positions) | set(target_weights))
+    for symbol in symbols:
+        price = price_map.get(symbol)
+        if price is None:
+            continue
+        current_qty = (
+            current_positions.get(symbol).qty if symbol in current_positions else 0.0
+        )
+        current_weight = current_values.get(symbol, 0.0) / total_value
+        target_weight = target_weights.get(symbol, 0.0)
+        turnover += abs(target_weight - current_weight)
+        target_value = target_weight * total_value
+        target_qty = target_value / price if price > 0 else 0.0
+        delta_qty = target_qty - current_qty
+        if abs(delta_qty) < 1e-6:
+            continue
+        side = "BUY" if delta_qty > 0 else "SELL"
+        orders.append(
+            RebalanceOrder(
+                symbol=symbol,
+                side=side,
+                quantity=round(delta_qty, 6),
+                notional=round(abs(delta_qty) * price, 2),
+            )
+        )
+
+    orders.sort(key=lambda order: order.symbol)
+    turnover *= 0.5
+    return orders, turnover
+
+
+def _reduce_turnover(
+    selected: Sequence[_Candidate],
+    exit_symbols: set[str],
+    current_positions: Mapping[str, Position],
+    holdings_cash: float,
+    price_map: Mapping[str, float],
+    available_weight: float,
+    *,
+    equal_weight: bool,
+    cap: float,
+    notes: list[str],
+) -> _Proposal:
+    mutable_selected = list(selected)
+    # Remove new candidates first to honor the cap.
+    for index in range(len(mutable_selected) - 1, -1, -1):
+        proposal = _build_proposal(
+            selected=mutable_selected,
+            exit_symbols=exit_symbols,
+            current_positions=current_positions,
+            holdings_cash=holdings_cash,
+            price_map=price_map,
+            available_weight=available_weight,
+            equal_weight=equal_weight,
+        )
+        if proposal.turnover <= cap:
+            proposal.notes.append(
+                f"Turnover {proposal.turnover:.4f} within cap {cap:.4f}"
+            )
+            return proposal
+        candidate = mutable_selected[index]
+        if candidate.is_existing:
+            continue
+        notes.append(f"Removed {candidate.symbol} to satisfy turnover cap {cap:.4f}")
+        mutable_selected.pop(index)
+
+    # Attempt final proposal with remaining candidates (existing only).
+    final_proposal = _build_proposal(
+        selected=mutable_selected,
+        exit_symbols=exit_symbols,
+        current_positions=current_positions,
+        holdings_cash=holdings_cash,
+        price_map=price_map,
+        available_weight=available_weight,
+        equal_weight=equal_weight,
+    )
+    if final_proposal.turnover > cap:
+        final_proposal.status = "TURNOVER_LIMIT"
+        final_proposal.orders.clear()
+        final_proposal.targets = []
+        final_proposal.turnover = 0.0
+        final_proposal.notes.append(f"Turnover cap {cap:.4f} prevented adjustments")
+        return final_proposal
+
+    final_proposal.notes.append(
+        f"Turnover adjusted to {final_proposal.turnover:.4f} within cap {cap:.4f}"
+    )
+    return final_proposal
+
+
+def _exit_orders(
+    exit_symbols: set[str],
+    current_positions: Mapping[str, Position],
+    price_map: Mapping[str, float],
+) -> tuple[RebalanceOrder, ...]:
+    orders: list[RebalanceOrder] = []
+    for symbol in sorted(exit_symbols):
+        position = current_positions.get(symbol)
+        if position is None or position.qty == 0:
+            continue
+        price = price_map.get(symbol)
+        if price is None:
+            continue
+        orders.append(
+            RebalanceOrder(
+                symbol=symbol,
+                side="SELL",
+                quantity=round(position.qty, 6),
+                notional=round(abs(position.qty) * price, 2),
+            )
+        )
+    return tuple(orders)
+
+
+def _serialize_result(result: RebalanceResult) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "date": result.as_of.isoformat(),
+        "status": result.status,
+        "cash_buffer": result.cash_buffer,
+        "turnover": result.turnover,
+        "targets": [
+            {
+                "symbol": target.symbol,
+                "target_weight": round(target.target_weight, 6),
+                "rationale": target.rationale,
+            }
+            for target in result.targets
+        ],
+        "orders": [
+            {
+                "symbol": order.symbol,
+                "side": order.side,
+                "quantity": order.quantity,
+                "notional": order.notional,
+            }
+            for order in result.orders
+        ],
+        "notes": list(result.notes),
+    }
+    if result.output_path is not None:
+        payload["output_path"] = str(result.output_path)
+    return payload
+
+
+__all__ = [
+    "RebalanceEngine",
+    "RebalanceOrder",
+    "RebalanceResult",
+    "RebalanceTarget",
+]

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -1,0 +1,302 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from trading_system.cli import app
+from trading_system.config import load_config
+from trading_system.rebalance import RebalanceEngine
+from trading_system.risk import load_holdings
+
+runner = CliRunner()
+
+CONFIG_TEMPLATE = """
+base_ccy: USD
+calendar: NYSE
+data:
+  provider: yahoo
+  lookback_days: 30
+universe:
+  tickers: [{tickers}]
+strategy:
+  type: trend_follow
+  entry: "close > sma_100"
+  exit: "close < sma_100"
+  rank: momentum_63d
+risk:
+  crash_threshold_pct: -0.08
+  drawdown_threshold_pct: -0.20
+rebalance:
+  cadence: monthly
+  max_positions: 3
+  equal_weight: true
+  min_weight: 0.1
+  cash_buffer: 0.1
+  turnover_cap_pct: 0.40
+notify:
+  email: ops@example.com
+paths:
+  data_raw: data/raw
+  data_curated: data/curated
+  reports: reports
+"""
+
+
+REBALANCE_CONFIG_TURNOVER = """
+base_ccy: USD
+calendar: NYSE
+data:
+  provider: yahoo
+  lookback_days: 30
+universe:
+  tickers: [{tickers}]
+strategy:
+  type: trend_follow
+  entry: "close > sma_100"
+  exit: "close < sma_100"
+  rank: momentum_63d
+risk:
+  crash_threshold_pct: -0.08
+  drawdown_threshold_pct: -0.20
+rebalance:
+  cadence: monthly
+  max_positions: 2
+  equal_weight: false
+  min_weight: 0.05
+  cash_buffer: 0.1
+  turnover_cap_pct: 0.05
+notify:
+  email: ops@example.com
+paths:
+  data_raw: data/raw
+  data_curated: data/curated
+  reports: reports
+"""
+
+
+SYMBOLS = ["AAPL", "MSFT", "NVDA"]
+
+
+def _write_config(tmp_path: Path, *, template: str = CONFIG_TEMPLATE) -> Path:
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(
+        template.format(tickers=", ".join(SYMBOLS)), encoding="utf-8"
+    )
+    return config_path
+
+
+def _write_curated(
+    config_path: Path, as_of: pd.Timestamp, prices: dict[str, float]
+) -> None:
+    config = load_config(config_path)
+    curated_dir = config.paths.data_curated / as_of.strftime("%Y-%m-%d")
+    curated_dir.mkdir(parents=True, exist_ok=True)
+    for symbol, price in prices.items():
+        frame = pd.DataFrame(
+            {
+                "date": [as_of],
+                "symbol": [symbol],
+                "close": [price],
+            }
+        )
+        frame.to_parquet(curated_dir / f"{symbol}.parquet", index=False)
+
+
+def _write_holdings(
+    tmp_path: Path, positions: list[dict[str, object]], *, cash: float = 0.0
+) -> Path:
+    holdings_path = tmp_path / "holdings.json"
+    payload = {
+        "as_of_date": "2024-05-31",
+        "positions": positions,
+        "cash": cash,
+        "base_ccy": "USD",
+    }
+    holdings_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return holdings_path
+
+
+def _make_signals(
+    as_of: pd.Timestamp, rows: list[tuple[str, str, float]]
+) -> pd.DataFrame:
+    data = {
+        "date": [as_of for _ in rows],
+        "symbol": [symbol for symbol, _, _ in rows],
+        "signal": [signal for _, signal, _ in rows],
+        "rank_score": [score for _, _, score in rows],
+    }
+    return pd.DataFrame(data)
+
+
+def test_rebalance_engine_generates_targets_and_orders(tmp_path: Path) -> None:
+    as_of = pd.Timestamp("2024-05-31")
+    config_path = _write_config(tmp_path)
+    _write_curated(config_path, as_of, {"AAPL": 150.0, "MSFT": 200.0, "NVDA": 300.0})
+    holdings_path = _write_holdings(
+        tmp_path,
+        [
+            {"symbol": "AAPL", "qty": 10, "cost_basis": 120.0},
+            {"symbol": "MSFT", "qty": 5, "cost_basis": 180.0},
+        ],
+        cash=1000.0,
+    )
+
+    config = load_config(config_path)
+    holdings = load_holdings(holdings_path)
+    signals = _make_signals(
+        as_of,
+        [
+            ("AAPL", "HOLD", 0.6),
+            ("MSFT", "EXIT", 0.2),
+            ("NVDA", "BUY", 0.9),
+        ],
+    )
+
+    engine = RebalanceEngine(config)
+    result = engine.evaluate(as_of, holdings=holdings, signals=signals)
+
+    assert result.status == "REBALANCE"
+    weights = {target.symbol: target.target_weight for target in result.targets}
+    assert pytest.approx(weights.get("AAPL", 0.0), rel=1e-6) == 0.45
+    assert pytest.approx(weights.get("NVDA", 0.0), rel=1e-6) == 0.45
+    assert weights.get("MSFT") == 0.0
+
+    orders = {order.symbol: order for order in result.orders}
+    assert orders["MSFT"].side == "SELL"
+    assert orders["NVDA"].side == "BUY"
+    assert result.turnover <= 0.400001
+
+
+def test_rebalance_engine_enforces_cadence(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path)
+    holdings_path = _write_holdings(tmp_path, [])
+    config = load_config(config_path)
+    holdings = load_holdings(holdings_path)
+    as_of = pd.Timestamp("2024-05-30")
+    signals = _make_signals(
+        as_of,
+        [
+            ("AAPL", "HOLD", 0.5),
+        ],
+    )
+
+    engine = RebalanceEngine(config)
+    result = engine.evaluate(as_of, holdings=holdings, signals=signals)
+
+    assert result.status == "NO_REBALANCE"
+    assert not result.orders
+    assert result.notes and "Cadence" in result.notes[0]
+
+
+def test_rebalance_engine_turnover_cap_limits_new_positions(tmp_path: Path) -> None:
+    as_of = pd.Timestamp("2024-05-31")
+    config_path = _write_config(tmp_path, template=REBALANCE_CONFIG_TURNOVER)
+    _write_curated(config_path, as_of, {"AAPL": 100.0, "NVDA": 300.0})
+    holdings_path = _write_holdings(
+        tmp_path,
+        [
+            {"symbol": "AAPL", "qty": 10, "cost_basis": 80.0},
+        ],
+    )
+    config = load_config(config_path)
+    holdings = load_holdings(holdings_path)
+    signals = _make_signals(
+        as_of,
+        [
+            ("AAPL", "HOLD", 0.2),
+            ("NVDA", "BUY", 0.9),
+        ],
+    )
+
+    engine = RebalanceEngine(config)
+    result = engine.evaluate(as_of, holdings=holdings, signals=signals)
+
+    assert result.status == "REBALANCE"
+    assert result.turnover <= 0.050001
+    symbols = [target.symbol for target in result.targets if target.target_weight > 0]
+    assert symbols == ["AAPL"]
+    assert any("turnover" in note.lower() for note in result.notes)
+
+
+def test_rebalance_cli_propose_writes_artifact(tmp_path: Path) -> None:
+    as_of = pd.Timestamp("2024-05-31")
+    config_path = _write_config(tmp_path)
+    _write_curated(config_path, as_of, {"AAPL": 150.0, "MSFT": 200.0})
+    holdings_path = _write_holdings(
+        tmp_path,
+        [
+            {"symbol": "AAPL", "qty": 10, "cost_basis": 120.0},
+            {"symbol": "MSFT", "qty": 5, "cost_basis": 180.0},
+        ],
+    )
+    signals = _make_signals(
+        as_of,
+        [
+            ("AAPL", "HOLD", 0.6),
+            ("MSFT", "EXIT", 0.2),
+        ],
+    )
+    signals_path = tmp_path / "signals.parquet"
+    signals.to_parquet(signals_path, index=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "rebalance",
+            "propose",
+            "--config",
+            str(config_path),
+            "--holdings",
+            str(holdings_path),
+            "--as-of",
+            as_of.strftime("%Y-%m-%d"),
+            "--signals",
+            str(signals_path),
+        ],
+    )
+
+    assert result.exit_code == 0
+    proposal_path = (
+        tmp_path / "reports" / as_of.strftime("%Y-%m-%d") / "rebalance_proposal.json"
+    )
+    assert proposal_path.exists()
+    payload = json.loads(proposal_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "REBALANCE"
+    assert payload["orders"]
+
+
+def test_rebalance_cli_dry_run_reports_status(tmp_path: Path) -> None:
+    as_of = pd.Timestamp("2024-05-30")
+    config_path = _write_config(tmp_path)
+    holdings_path = _write_holdings(tmp_path, [])
+    signals = _make_signals(
+        as_of,
+        [
+            ("AAPL", "HOLD", 0.5),
+        ],
+    )
+    signals_path = tmp_path / "signals.parquet"
+    signals.to_parquet(signals_path, index=False)
+
+    result = runner.invoke(
+        app,
+        [
+            "rebalance",
+            "dry-run",
+            "--config",
+            str(config_path),
+            "--holdings",
+            str(holdings_path),
+            "--as-of",
+            as_of.strftime("%Y-%m-%d"),
+            "--signals",
+            str(signals_path),
+            "--max-candidates",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "NO_REBALANCE" in result.stdout


### PR DESCRIPTION
## Story
- [S-06](docs/stories/S-06.md)

## Summary
- add a RebalanceEngine that builds deterministic target weights, orders, and turnover-aware proposals
- expose new `ts rebalance` CLI commands with shared helpers for loading signals and rendering summaries
- cover the rebalancer with unit tests and CLI tests exercising cadence, turnover caps, and artifact creation

## Testing
- `PYTHONPATH=src poetry run pytest`
- `PYTHONPATH=src poetry run pytest tests/test_rebalance.py`

## Manual Validation
- `PYTHONPATH=src python -m trading_system.cli rebalance dry-run --config /tmp/tmp.b7nxeoMQPe/config.yml --holdings /tmp/tmp.b7nxeoMQPe/holdings.json --signals /tmp/tmp.b7nxeoMQPe/signals.parquet --as-of 2024-05-31`
- `PYTHONPATH=src python -m trading_system.cli rebalance propose --config /tmp/tmp.b7nxeoMQPe/config.yml --holdings /tmp/tmp.b7nxeoMQPe/holdings.json --signals /tmp/tmp.b7nxeoMQPe/signals.parquet --as-of 2024-05-31`

## Compliance
- [x] TECH_DESIGN_REQUIREMENTS.md
- [x] WORKFLOW.md

------
https://chatgpt.com/codex/tasks/task_e_68cfa516aa90832095c54309f64fbed7