### PR TITLE
S-11: Backtest Engine (Deterministic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ and [`docs/TECH_DESIGN_REQUIREMENTS.md`](docs/TECH_DESIGN_REQUIREMENTS.md).
   orchestrates pull → preprocess → risk → report → notify with structured logging.
 - `poetry run ts run rebalance --config configs/sample-config.yml --holdings data/holdings.json --asof YYYY-MM-DD --force`
   runs the full pipeline including signals/rebalance even when cadence is overriden.
-- `poetry run ts backtest run --config configs/sample-config.yml --start YYYY-MM-DD --end YYYY-MM-DD --output reports/backtests/demo`
-  currently reports pending support (story S-11) while preserving the CLI surface.
+- `poetry run ts backtest run --config configs/sample-config.yml --start YYYY-MM-DD --end YYYY-MM-DD --output reports/backtests/demo --label smoke`
+  executes the deterministic backtest engine and writes metrics, equity curve, trade log, and optional Plotly HTML chart.
+- `poetry run ts backtest compare --baseline reports/backtests/base --candidate reports/backtests/experiment`
+  highlights metric deltas across backtest scenarios.
 
 ### Handy Automation Commands
 

--- a/configs/sample-config.yml
+++ b/configs/sample-config.yml
@@ -35,3 +35,10 @@ paths:
 preprocess:
   forward_fill_limit: 1
   rolling_peak_window: 252
+backtest:
+  initial_cash: 100000
+  slippage_pct: 0.001
+  commission_per_trade: 1.0
+  annual_risk_free_rate: 0.02
+  include_chart: true
+  trading_days_per_year: 252

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ mypy_path = ["src"]
 module = ["yfinance"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = ["plotly", "plotly.graph_objects"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra"

--- a/src/trading_system/__init__.py
+++ b/src/trading_system/__init__.py
@@ -1,5 +1,6 @@
 """Trading System package."""
 
+from trading_system.backtest import BacktestEngine
 from trading_system.config import Config, load_config
 from trading_system.data import run_data_pull
 from trading_system.rebalance import RebalanceEngine
@@ -9,6 +10,7 @@ from trading_system.signals import StrategyEngine
 
 __all__ = [
     "__version__",
+    "BacktestEngine",
     "Config",
     "load_config",
     "run_data_pull",

--- a/src/trading_system/backtest/__init__.py
+++ b/src/trading_system/backtest/__init__.py
@@ -1,0 +1,492 @@
+"""Deterministic backtesting harness built on live trading components."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from trading_system.config import BacktestConfig, Config
+from trading_system.rebalance import RebalanceEngine, RebalanceOrder
+from trading_system.risk import HoldingsSnapshot, Position
+from trading_system.signals import StrategyEngine
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class BacktestTrade:
+    """Executed trade captured during a backtest run."""
+
+    date: date
+    symbol: str
+    side: str
+    quantity: float
+    price: float
+    fill_price: float
+    commission: float
+    slippage_cost: float
+
+    @property
+    def notional(self) -> float:
+        return round(abs(self.quantity) * self.fill_price, 8)
+
+
+@dataclass(slots=True)
+class BacktestResult:
+    """Aggregated artefacts and metrics produced by the engine."""
+
+    start: date
+    end: date
+    metrics: dict[str, Any]
+    equity_curve: pd.DataFrame
+    trades: pd.DataFrame
+    manifest: dict[str, str]
+    output_dir: Path | None = None
+    metrics_path: Path | None = None
+    equity_path: Path | None = None
+    trades_path: Path | None = None
+    chart_path: Path | None = None
+
+
+@dataclass(slots=True)
+class _PortfolioState:
+    cash: float
+    positions: dict[str, float] = field(default_factory=dict)
+
+    def snapshot(self, *, as_of: date, base_ccy: str) -> HoldingsSnapshot:
+        positions_snapshot = tuple(
+            Position(symbol=symbol, qty=qty)
+            for symbol, qty in sorted(self.positions.items())
+            if abs(qty) > 1e-9
+        )
+        return HoldingsSnapshot(
+            as_of_date=as_of,
+            positions=positions_snapshot,
+            cash=self.cash,
+            base_ccy=base_ccy,
+        )
+
+
+class BacktestEngine:
+    """Simulate historical performance using live strategy components."""
+
+    def __init__(self, config: Config) -> None:
+        self._config = config
+        self._strategy = StrategyEngine(config)
+        self._rebalance = RebalanceEngine(config)
+        self._backtest_cfg = config.backtest or BacktestConfig()
+
+    def run(
+        self,
+        *,
+        start: date | str | pd.Timestamp,
+        end: date | str | pd.Timestamp,
+        output_dir: Path,
+        label: str | None = None,
+        dry_run: bool = False,
+        include_chart: bool | None = None,
+    ) -> BacktestResult:
+        """Execute the backtest and optionally persist artefacts."""
+
+        start_ts = _normalize_date(start)
+        end_ts = _normalize_date(end)
+        if end_ts < start_ts:
+            raise ValueError("Backtest end date must be on or after the start date")
+
+        include_chart = (
+            self._backtest_cfg.include_chart if include_chart is None else include_chart
+        )
+
+        output_dir = output_dir.resolve()
+        if not dry_run:
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+        trading_days = pd.bdate_range(start=start_ts, end=end_ts)
+        if trading_days.empty:
+            raise ValueError("No trading days found between start and end dates")
+
+        state = _PortfolioState(cash=float(self._backtest_cfg.initial_cash))
+        equity_records: list[dict[str, Any]] = []
+        trades: list[BacktestTrade] = []
+        peak_equity = state.cash
+        previous_equity = state.cash
+        turnover_total = 0.0
+        rebalance_events = 0
+
+        for current_ts in trading_days:
+            as_of_date = current_ts.date()
+            strategy_result = self._strategy.evaluate(current_ts)
+            price_map = _extract_prices(strategy_result.evaluations)
+            _assert_price_coverage(price_map, state.positions.keys())
+
+            force_rebalance = not state.positions
+            rebalance_result = self._rebalance.evaluate(
+                current_ts,
+                holdings=state.snapshot(
+                    as_of=as_of_date, base_ccy=self._config.base_ccy
+                ),
+                signals=strategy_result.frame,
+                force=force_rebalance,
+            )
+
+            if rebalance_result.orders:
+                day_trades = self._execute_orders(
+                    as_of=as_of_date,
+                    orders=rebalance_result.orders,
+                    price_map=price_map,
+                    state=state,
+                )
+                trades.extend(day_trades)
+                turnover_total += float(rebalance_result.turnover)
+                rebalance_events += 1
+
+            equity = _portfolio_equity(state, price_map)
+            daily_return = (
+                0.0 if not equity_records else (equity / previous_equity) - 1.0
+            )
+            peak_equity = max(peak_equity, equity)
+            drawdown = (equity / peak_equity) - 1.0 if peak_equity > 0 else 0.0
+            previous_equity = equity
+
+            equity_records.append(
+                {
+                    "date": as_of_date.isoformat(),
+                    "equity": _round(equity),
+                    "cash": _round(state.cash),
+                    "daily_return": _round(daily_return),
+                    "drawdown": _round(drawdown),
+                }
+            )
+
+        equity_frame = pd.DataFrame(equity_records)
+        trades_frame = _trades_frame(trades)
+        metrics = self._compute_metrics(
+            equity_frame=equity_frame,
+            turnover_total=turnover_total,
+            rebalance_events=rebalance_events,
+            trades_count=len(trades),
+            label=label,
+        )
+
+        metrics_path = output_dir / "metrics.json"
+        equity_path = output_dir / "equity_curve.csv"
+        trades_path = output_dir / "trades.csv"
+        chart_path = output_dir / "equity_curve.html" if include_chart else None
+        manifest: dict[str, str] = {}
+
+        if not dry_run:
+            _write_json(metrics_path, metrics)
+            equity_frame.to_csv(equity_path, index=False)
+            trades_frame.to_csv(trades_path, index=False)
+            manifest.update(
+                {
+                    "metrics": str(metrics_path),
+                    "equity_curve": str(equity_path),
+                    "trades": str(trades_path),
+                }
+            )
+
+            if include_chart:
+                chart_path = _write_chart(
+                    path=chart_path,
+                    equity_frame=equity_frame,
+                    label=label,
+                )
+                manifest["equity_curve_chart"] = str(chart_path)
+
+            manifest_path = output_dir / "manifest.json"
+            manifest_with_self = {**manifest, "manifest": str(manifest_path)}
+            _write_json(manifest_path, manifest_with_self)
+            manifest = manifest_with_self
+
+        logger.info(
+            "Backtest completed: %s to %s | final_equity=%s | total_return=%.4f",
+            metrics["start"],
+            metrics["end"],
+            metrics["final_equity"],
+            metrics["total_return"],
+        )
+
+        return BacktestResult(
+            start=start_ts.date(),
+            end=end_ts.date(),
+            metrics=metrics,
+            equity_curve=equity_frame,
+            trades=trades_frame,
+            manifest=manifest,
+            output_dir=None if dry_run else output_dir,
+            metrics_path=None if dry_run else metrics_path,
+            equity_path=None if dry_run else equity_path,
+            trades_path=None if dry_run else trades_path,
+            chart_path=None if dry_run else chart_path,
+        )
+
+    def _compute_metrics(
+        self,
+        *,
+        equity_frame: pd.DataFrame,
+        turnover_total: float,
+        rebalance_events: int,
+        trades_count: int,
+        label: str | None,
+    ) -> dict[str, Any]:
+        initial_cash = float(self._backtest_cfg.initial_cash)
+        trading_days_per_year = max(int(self._backtest_cfg.trading_days_per_year), 1)
+        annual_rf = float(self._backtest_cfg.annual_risk_free_rate)
+
+        trading_days = int(equity_frame.shape[0])
+        final_equity = (
+            float(equity_frame["equity"].iloc[-1]) if trading_days else initial_cash
+        )
+        total_return = (final_equity / initial_cash) - 1.0 if initial_cash else 0.0
+        years = trading_days / trading_days_per_year
+        if years > 0 and final_equity > 0 and initial_cash > 0:
+            cagr = (final_equity / initial_cash) ** (1.0 / years) - 1.0
+        else:
+            cagr = 0.0
+
+        returns = equity_frame["daily_return"].to_numpy(copy=True)
+        if returns.size:
+            returns = returns[1:]  # drop the artificial first zero return
+        mean_return = returns.mean() if returns.size else 0.0
+        std_return = returns.std(ddof=0) if returns.size else 0.0
+        volatility = std_return * math.sqrt(trading_days_per_year)
+        rf_daily = (1.0 + annual_rf) ** (1.0 / trading_days_per_year) - 1.0
+        excess_returns = returns - rf_daily if returns.size else returns
+        sharpe = (
+            (excess_returns.mean() / std_return) * math.sqrt(trading_days_per_year)
+            if std_return > 0
+            else 0.0
+        )
+        downside = returns[returns < 0]
+        downside_std = downside.std(ddof=0) if downside.size else 0.0
+        sortino = (
+            (mean_return - rf_daily) / downside_std * math.sqrt(trading_days_per_year)
+            if downside_std > 0
+            else float("inf") if returns.size and (returns >= 0).all() else 0.0
+        )
+
+        max_drawdown = float(equity_frame["drawdown"].min()) if trading_days else 0.0
+        positive_days = (returns > 0).sum() if returns.size else 0
+        hit_rate = positive_days / returns.size if returns.size else 0.0
+        turnover_average = (
+            turnover_total / rebalance_events if rebalance_events else 0.0
+        )
+
+        metrics: dict[str, Any] = {
+            "start": equity_frame["date"].iloc[0] if trading_days else None,
+            "end": equity_frame["date"].iloc[-1] if trading_days else None,
+            "trading_days": trading_days,
+            "initial_cash": _round(initial_cash),
+            "final_equity": _round(final_equity),
+            "total_return": _round(total_return),
+            "cagr": _round(cagr),
+            "volatility": _round(volatility),
+            "sharpe": _round(sharpe),
+            "sortino": _round(sortino),
+            "max_drawdown": _round(max_drawdown),
+            "hit_rate": _round(hit_rate),
+            "turnover_total": _round(turnover_total),
+            "turnover_average": _round(turnover_average),
+            "rebalance_events": rebalance_events,
+            "trades_executed": trades_count,
+            "annual_risk_free_rate": _round(annual_rf),
+        }
+        if label:
+            metrics["label"] = label
+        return metrics
+
+    def _execute_orders(
+        self,
+        *,
+        as_of: date,
+        orders: Iterable[RebalanceOrder],
+        price_map: Mapping[str, float],
+        state: _PortfolioState,
+    ) -> list[BacktestTrade]:
+        slippage_pct = float(self._backtest_cfg.slippage_pct)
+        commission = float(self._backtest_cfg.commission_per_trade)
+        trades: list[BacktestTrade] = []
+
+        for order in sorted(orders, key=lambda item: item.symbol):
+            price = price_map.get(order.symbol)
+            if price is None:
+                raise ValueError(f"Missing price for symbol {order.symbol} on {as_of}")
+            quantity = float(order.quantity)
+            if abs(quantity) < 1e-9:
+                continue
+
+            if order.side == "BUY":
+                fill_price = price * (1.0 + slippage_pct)
+                state.cash -= quantity * fill_price
+                state.cash -= commission
+                state.positions[order.symbol] = (
+                    state.positions.get(order.symbol, 0.0) + quantity
+                )
+                slippage_cost = (fill_price - price) * quantity
+            elif order.side == "SELL":
+                fill_price = price * (1.0 - slippage_pct)
+                state.cash += quantity * fill_price
+                state.cash -= commission
+                state.positions[order.symbol] = (
+                    state.positions.get(order.symbol, 0.0) - quantity
+                )
+                if abs(state.positions[order.symbol]) < 1e-9:
+                    del state.positions[order.symbol]
+                slippage_cost = (price - fill_price) * quantity
+            else:  # pragma: no cover - defensive
+                raise ValueError(f"Unsupported side {order.side}")
+
+            trades.append(
+                BacktestTrade(
+                    date=as_of,
+                    symbol=order.symbol,
+                    side=order.side,
+                    quantity=_round(quantity),
+                    price=_round(price),
+                    fill_price=_round(fill_price),
+                    commission=_round(commission),
+                    slippage_cost=_round(slippage_cost),
+                )
+            )
+
+        if state.cash < -1e-6:
+            logger.warning(
+                "Portfolio cash negative after trades on %s: %.6f",
+                as_of,
+                state.cash,
+            )
+
+        return trades
+
+
+def _portfolio_equity(state: _PortfolioState, price_map: Mapping[str, float]) -> float:
+    equity = state.cash
+    for symbol, qty in state.positions.items():
+        price = price_map.get(symbol)
+        if price is None:
+            raise ValueError(f"Missing price for symbol {symbol}")
+        equity += qty * price
+    return float(equity)
+
+
+def _extract_prices(
+    evaluations: Mapping[str, Any]
+) -> dict[str, float]:  # Mapping[str, SymbolEvaluation]
+    prices: dict[str, float] = {}
+    for symbol, evaluation in evaluations.items():
+        indicators = getattr(evaluation, "indicators", {})
+        close = indicators.get("close")
+        if close is None or math.isnan(close):
+            raise ValueError(f"Curated data missing closing price for {symbol}")
+        prices[symbol] = float(close)
+    return prices
+
+
+def _assert_price_coverage(
+    price_map: Mapping[str, float], symbols: Iterable[str]
+) -> None:
+    missing = [symbol for symbol in symbols if symbol not in price_map]
+    if missing:
+        raise ValueError(
+            "Missing prices for positions: " + ", ".join(sorted(set(missing)))
+        )
+
+
+def _trades_frame(trades: list[BacktestTrade]) -> pd.DataFrame:
+    if not trades:
+        return pd.DataFrame(
+            columns=[
+                "date",
+                "symbol",
+                "side",
+                "quantity",
+                "price",
+                "fill_price",
+                "commission",
+                "slippage_cost",
+                "notional",
+            ]
+        )
+
+    data = [
+        {
+            "date": trade.date.isoformat(),
+            "symbol": trade.symbol,
+            "side": trade.side,
+            "quantity": trade.quantity,
+            "price": trade.price,
+            "fill_price": trade.fill_price,
+            "commission": trade.commission,
+            "slippage_cost": trade.slippage_cost,
+            "notional": _round(trade.notional),
+        }
+        for trade in trades
+    ]
+    return pd.DataFrame(data)
+
+
+def _normalize_date(value: date | str | pd.Timestamp) -> pd.Timestamp:
+    timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is not None:
+        timestamp = timestamp.tz_convert(None)
+    return timestamp.normalize()
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+
+def _write_chart(
+    *, path: Path | None, equity_frame: pd.DataFrame, label: str | None
+) -> Path:
+    assert path is not None
+    figure = go.Figure()
+    figure.add_trace(
+        go.Scatter(
+            x=equity_frame["date"],
+            y=equity_frame["equity"],
+            name="Equity",
+            mode="lines",
+        )
+    )
+    figure.add_trace(
+        go.Scatter(
+            x=equity_frame["date"],
+            y=equity_frame["drawdown"],
+            name="Drawdown",
+            mode="lines",
+            yaxis="y2",
+        )
+    )
+    figure.update_layout(
+        title=f"Backtest Equity Curve{f' – {label}' if label else ''}",
+        yaxis=dict(title="Equity"),
+        yaxis2=dict(title="Drawdown", overlaying="y", side="right"),
+        xaxis=dict(title="Date"),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+    )
+    figure.write_html(
+        path,
+        include_plotlyjs="cdn",
+        full_html=True,
+        div_id="equity_curve_chart",
+    )
+    return path
+
+
+def _round(value: float, digits: int = 8) -> float:
+    return round(float(value), digits)
+
+
+__all__ = ["BacktestEngine", "BacktestResult", "BacktestTrade"]

--- a/src/trading_system/config.py
+++ b/src/trading_system/config.py
@@ -80,6 +80,20 @@ class NotifyConfig(BaseModel):
     slack_webhook: str | None = None
 
 
+class BacktestConfig(BaseModel):
+    """Deterministic backtest parameters."""
+
+    model_config = ConfigDict(extra="allow")
+
+    initial_cash: float = 100_000.0
+    slippage_pct: float = 0.001
+    commission_per_trade: float = 0.0
+    annual_risk_free_rate: float = 0.0
+    seed: int | None = 7_318_009
+    include_chart: bool = True
+    trading_days_per_year: int = 252
+
+
 class PathsConfig(BaseModel):
     """Canonical project paths."""
 
@@ -121,6 +135,7 @@ class Config(BaseModel):
     notify: NotifyConfig
     paths: PathsConfig
     preprocess: PreprocessConfig | None = None
+    backtest: BacktestConfig | None = None
 
 
 def _resolve_directories(
@@ -177,6 +192,7 @@ __all__ = [
     "RiskConfig",
     "RebalanceConfig",
     "NotifyConfig",
+    "BacktestConfig",
     "PathsConfig",
     "PreprocessConfig",
     "load_config",

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from typer.testing import CliRunner
+
+from trading_system.backtest import BacktestEngine
+from trading_system.cli import app
+from trading_system.config import Config, load_config
+
+CONFIG_TEMPLATE = """
+base_ccy: USD
+calendar: NYSE
+data:
+  provider: yahoo
+  lookback_days: 420
+universe:
+  tickers: [{tickers}]
+strategy:
+  type: trend_follow
+  entry: "close > sma_100"
+  exit: "close < sma_100"
+  rank: momentum_63d
+risk:
+  crash_threshold_pct: -0.08
+  drawdown_threshold_pct: -0.20
+rebalance:
+  cadence: monthly
+  max_positions: 4
+  equal_weight: true
+  min_weight: 0.05
+  cash_buffer: 0.05
+notify:
+  email: ops@example.com
+  slack_webhook: https://hooks.slack.test/XYZ
+paths:
+  data_raw: {base}/data/raw
+  data_curated: {base}/data/curated
+  reports: {base}/reports
+backtest:
+  initial_cash: 100000
+  slippage_pct: 0.001
+  commission_per_trade: 1.0
+  annual_risk_free_rate: 0.0
+  include_chart: true
+  trading_days_per_year: 252
+"""
+
+
+def _write_config(tmp_path: Path, tickers: list[str]) -> Path:
+    config_text = CONFIG_TEMPLATE.format(tickers=", ".join(tickers), base=tmp_path)
+    config_path = tmp_path / "config.yml"
+    config_path.write_text(config_text, encoding="utf-8")
+    return config_path
+
+
+def _build_history_frames(
+    dates: pd.DatetimeIndex, tickers: list[str]
+) -> dict[str, pd.DataFrame]:
+    frames: dict[str, pd.DataFrame] = {}
+    for index, symbol in enumerate(tickers):
+        upward = index % 2 == 0
+        slope = 0.6 if upward else -0.4
+        base = 100 + index * 5
+        prices = base + slope * np.arange(len(dates))
+        series = pd.Series(prices, index=dates, dtype=float)
+        values = series.to_numpy(copy=True)
+        sma_offset = -1.0 if upward else 1.0
+        frame = pd.DataFrame(
+            {
+                "date": dates,
+                "symbol": symbol,
+                "open": values,
+                "high": values,
+                "low": values,
+                "close": values,
+                "volume": np.full(len(series), 1_000),
+                "adj_close": values,
+                "sma_100": values + sma_offset,
+                "sma_200": values + sma_offset,
+                "ret_1d": series.pct_change().fillna(0.0).values,
+                "ret_20d": series.pct_change(20).fillna(0.0).values,
+                "rolling_peak": series.cummax().values,
+            }
+        )
+        frames[symbol] = frame
+    return frames
+
+
+def _write_curated_history(
+    config: Config,
+    frames: dict[str, pd.DataFrame],
+    as_of_dates: pd.DatetimeIndex,
+) -> None:
+    for as_of in as_of_dates:
+        curated_dir = config.paths.data_curated / as_of.strftime("%Y-%m-%d")
+        curated_dir.mkdir(parents=True, exist_ok=True)
+        for symbol, frame in frames.items():
+            filtered = frame[frame["date"] <= as_of]
+            filtered.to_parquet(curated_dir / f"{symbol}.parquet", index=False)
+
+
+def test_backtest_engine_produces_deterministic_metrics(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, ["AAA", "BBB"])
+    config = load_config(config_path)
+    start = pd.Timestamp("2024-01-02")
+    end = pd.Timestamp("2024-04-30")
+    history_dates = pd.bdate_range(end=end, periods=120)
+    frames = _build_history_frames(history_dates, ["AAA", "BBB"])
+    as_of_dates = pd.bdate_range(start=start, end=end)
+    _write_curated_history(config, frames, as_of_dates)
+
+    engine = BacktestEngine(config)
+    output_dir = config.paths.reports / "backtests" / "demo"
+    result = engine.run(
+        start=start.date(),
+        end=end.date(),
+        output_dir=output_dir,
+        label="demo",
+        include_chart=False,
+    )
+
+    metrics = result.metrics
+    assert metrics["label"] == "demo"
+    assert metrics["trading_days"] == len(as_of_dates)
+    assert metrics["final_equity"] > metrics["initial_cash"] * 0.9
+    assert not result.equity_curve.empty
+    assert (output_dir / "metrics.json").exists()
+    assert (output_dir / "equity_curve.csv").exists()
+    assert (output_dir / "trades.csv").exists()
+
+    dry_run_metrics = engine.run(
+        start=start.date(),
+        end=end.date(),
+        output_dir=output_dir,
+        label="demo",
+        dry_run=True,
+        include_chart=False,
+    ).metrics
+    assert dry_run_metrics == metrics
+
+
+def test_backtest_cli_run_and_compare(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path, ["AAA"])
+    config = load_config(config_path)
+    start = pd.Timestamp("2024-02-01")
+    end = pd.Timestamp("2024-03-15")
+    history_dates = pd.bdate_range(end=end, periods=80)
+    frames = _build_history_frames(history_dates, ["AAA"])
+    as_of_dates = pd.bdate_range(start=start, end=end)
+    _write_curated_history(config, frames, as_of_dates)
+
+    runner = CliRunner()
+    base_dir = config.paths.reports / "backtests" / "base"
+    result = runner.invoke(
+        app,
+        [
+            "backtest",
+            "run",
+            "--config",
+            str(config_path),
+            "--start",
+            start.strftime("%Y-%m-%d"),
+            "--end",
+            end.strftime("%Y-%m-%d"),
+            "--output",
+            str(base_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert (base_dir / "metrics.json").exists()
+    assert (base_dir / "equity_curve.html").exists()
+
+    candidate_dir = config.paths.reports / "backtests" / "candidate"
+    result_candidate = runner.invoke(
+        app,
+        [
+            "backtest",
+            "run",
+            "--config",
+            str(config_path),
+            "--start",
+            start.strftime("%Y-%m-%d"),
+            "--end",
+            end.strftime("%Y-%m-%d"),
+            "--output",
+            str(candidate_dir),
+            "--label",
+            "candidate",
+            "--no-chart",
+        ],
+    )
+    assert result_candidate.exit_code == 0, result_candidate.output
+    assert (candidate_dir / "metrics.json").exists()
+    assert not (candidate_dir / "equity_curve.html").exists()
+
+    compare = runner.invoke(
+        app,
+        [
+            "backtest",
+            "compare",
+            "--baseline",
+            str(base_dir),
+            "--candidate",
+            str(candidate_dir),
+        ],
+    )
+    assert compare.exit_code == 0, compare.output
+    assert "delta" in compare.output


### PR DESCRIPTION
Story Link

@S-11: Backtest Engine (Deterministic)
Summary

Reuse the live StrategyEngine and RebalanceEngine to drive a deterministic backtest harness that produces metrics, equity curves, trade logs, and manifests (optionally with Plotly charts) via BacktestEngine.
Extend configuration/CLI surfaces with typed BacktestConfig, full-featured ts backtest run/compare commands, formatted metric output, and documentation updates.
Add synthetic-data integration tests covering engine determinism, chart toggles, artifact persistence, and CLI comparisons.
Tests Run

poetry run ci
poetry run pytest
Evidence / Manual Validation

poetry run ts backtest run --config configs/sample-config.yml --start 2024-02-01 --end 2024-03-29 --output reports/backtests/smoke --label manual
shasum reports/backtests/smoke/metrics.json
poetry run ts backtest compare --baseline reports/backtests/smoke --candidate reports/backtests/smoke
Checklist

 TECH_DESIGN_REQUIREMENTS.md upheld
 WORKFLOW.md upheld
 Lint / typecheck / tests green
 Backtest CLI flows exercised
 Docs and configs updated