### PR TITLE
S-12: implement observability manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ and [`docs/TECH_DESIGN_REQUIREMENTS.md`](docs/TECH_DESIGN_REQUIREMENTS.md).
   orchestrates pull → preprocess → risk → report → notify with structured logging.
 - `poetry run ts run rebalance --config configs/sample-config.yml --holdings data/holdings.json --asof YYYY-MM-DD --force`
   runs the full pipeline including signals/rebalance even when cadence is overriden.
+- `poetry run ts observability manifest --run reports/YYYY-MM-DD`
+  validates artifact hashes, sizes, and row counts while printing a summary table.
+- `poetry run ts observability tail --run reports/YYYY-MM-DD`
+  streams the structured JSON logs captured during the pipeline run.
 - `poetry run ts backtest run --config configs/sample-config.yml --start YYYY-MM-DD --end YYYY-MM-DD --output reports/backtests/demo --label smoke`
   executes the deterministic backtest engine and writes metrics, equity curve, trade log, and optional Plotly HTML chart.
 - `poetry run ts backtest compare --baseline reports/backtests/base --candidate reports/backtests/experiment`

--- a/src/trading_system/cli.py
+++ b/src/trading_system/cli.py
@@ -27,6 +27,11 @@ from trading_system.notify import (
     NotificationStatus,
     load_report_summary,
 )
+from trading_system.observability.manifest import (
+    PipelineManifest,
+    load_manifest,
+    validate_manifest,
+)
 from trading_system.orchestrator import (
     PipelineExecutionError,
     PipelineSummary,
@@ -50,6 +55,7 @@ risk_app = typer.Typer(help="Risk evaluation commands.")
 notify_app = typer.Typer(help="Notification delivery commands.")
 backtest_app = typer.Typer(help="Backtesting commands.")
 run_app = typer.Typer(help="Pipeline orchestration commands.")
+observability_app = typer.Typer(help="Observability and auditing commands.")
 app.add_typer(config_app, name="config")
 app.add_typer(data_app, name="data")
 app.add_typer(signals_app, name="signals")
@@ -59,6 +65,7 @@ app.add_typer(risk_app, name="risk")
 app.add_typer(notify_app, name="notify")
 app.add_typer(backtest_app, name="backtest")
 app.add_typer(run_app, name="run")
+app.add_typer(observability_app, name="observability")
 console = Console()
 
 _DEFAULT_DOCTOR_TOOLS: tuple[str, ...] = (
@@ -179,6 +186,34 @@ def _channel_option(default: str = "all") -> Any:
 
 def _log_toggle() -> Any:
     return typer.Option(True, help="Write pipeline logs to reports/<asof>/run.log.")
+
+
+def _run_directory_option() -> Any:
+    return typer.Option(  # noqa: B008 - CLI option definition
+        ...,
+        "--run",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        readable=True,
+        help="Pipeline run directory (e.g., reports/2024-05-02).",
+    )
+
+
+def _format_size(value: int | None) -> str:
+    return f"{value:,}" if value is not None else "—"
+
+
+def _format_rows(value: int | None) -> str:
+    return f"{value:,}" if value is not None else "—"
+
+
+def _load_manifest_for_run(run_dir: Path) -> tuple[Path, PipelineManifest]:
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest file not found in {run_dir}")
+    manifest = load_manifest(manifest_path)
+    return manifest_path, manifest
 
 
 def _resolve_log_path(config: Config, as_of_date: date, enabled: bool) -> Path | None:
@@ -793,16 +828,25 @@ def run_daily(
 
     summary: PipelineSummary | None = None
     try:
-        with pipeline_logging(log_path):
+        with pipeline_logging(
+            log_path,
+            context={
+                "pipeline": "daily",
+                "as_of": as_of_date.isoformat(),
+                "config": str(config_path),
+            },
+        ):
             summary = run_daily_pipeline(
                 config=config,
                 provider=provider,
                 as_of=as_of_date,
                 holdings=holdings,
                 holdings_path=holdings_path,
+                config_path=config_path,
                 dry_run=dry_run,
                 force=force,
                 channels=channels,
+                log_path=log_path,
             )
     except PipelineExecutionError as exc:
         _print_pipeline_summary(exc.summary)
@@ -835,16 +879,25 @@ def run_rebalance(
 
     summary: PipelineSummary | None = None
     try:
-        with pipeline_logging(log_path):
+        with pipeline_logging(
+            log_path,
+            context={
+                "pipeline": "rebalance",
+                "as_of": as_of_date.isoformat(),
+                "config": str(config_path),
+            },
+        ):
             summary = run_rebalance_pipeline(
                 config=config,
                 provider=provider,
                 as_of=as_of_date,
                 holdings=holdings,
                 holdings_path=holdings_path,
+                config_path=config_path,
                 dry_run=dry_run,
                 force=force,
                 channels=channels,
+                log_path=log_path,
             )
     except PipelineExecutionError as exc:
         _print_pipeline_summary(exc.summary)
@@ -852,6 +905,80 @@ def run_rebalance(
         raise typer.Exit(code=1) from exc
 
     _print_pipeline_summary(summary)
+
+
+@observability_app.command("manifest")
+def observability_manifest(
+    run_dir: Path = _run_directory_option(),  # noqa: B008 - Typer option factory
+) -> None:
+    """Display and validate the manifest for a completed run."""
+
+    try:
+        manifest_path, manifest = _load_manifest_for_run(run_dir)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    console.print(f"Manifest file: [bold]{manifest_path}[/bold]")
+    console.print(
+        f"Pipeline: [green]{manifest.run.pipeline}[/green] as_of={manifest.run.as_of}"
+    )
+
+    table = Table("artifact", "kind", "size (bytes)", "rows", "sha256")
+    for artifact in manifest.run.artifacts:
+        table.add_row(
+            f"run::{artifact.key}",
+            artifact.kind,
+            _format_size(artifact.size_bytes),
+            _format_rows(artifact.row_count),
+            artifact.sha256 or "—",
+        )
+    for step in manifest.steps:
+        for artifact in step.artifacts:
+            table.add_row(
+                f"{step.name}::{artifact.key}",
+                artifact.kind,
+                _format_size(artifact.size_bytes),
+                _format_rows(artifact.row_count),
+                artifact.sha256 or "—",
+            )
+
+    console.print(table)
+
+    errors = validate_manifest(manifest)
+    if errors:
+        console.print("[red]Validation mismatches detected:[/red]")
+        for item in errors:
+            console.print(f" - {item}")
+        raise typer.Exit(code=1)
+
+
+@observability_app.command("tail")
+def observability_tail(
+    run_dir: Path = _run_directory_option(),  # noqa: B008 - Typer option factory
+) -> None:
+    """Stream structured logs for a pipeline run."""
+
+    try:
+        _, manifest = _load_manifest_for_run(run_dir)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    log_path_raw = manifest.run.log_path
+    if not log_path_raw:
+        console.print("[yellow]Manifest does not reference a log file.[/yellow]")
+        raise typer.Exit(code=1)
+
+    log_path = Path(log_path_raw)
+    if not log_path.is_file():
+        console.print(f"[red]Log file not found: {log_path}[/red]")
+        raise typer.Exit(code=1)
+
+    console.print(f"Streaming log: [bold]{log_path}[/bold]")
+    with log_path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            typer.echo(line.rstrip())
 
 
 @backtest_app.command("run")

--- a/src/trading_system/cli.py
+++ b/src/trading_system/cli.py
@@ -924,7 +924,12 @@ def observability_manifest(
         f"Pipeline: [green]{manifest.run.pipeline}[/green] as_of={manifest.run.as_of}"
     )
 
-    table = Table("artifact", "kind", "size (bytes)", "rows", "sha256")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("artifact", overflow="fold", no_wrap=True)
+    table.add_column("kind")
+    table.add_column("size (bytes)", justify="right")
+    table.add_column("rows", justify="right")
+    table.add_column("sha256", overflow="ellipsis", max_width=20)
     for artifact in manifest.run.artifacts:
         table.add_row(
             f"run::{artifact.key}",

--- a/src/trading_system/observability/__init__.py
+++ b/src/trading_system/observability/__init__.py
@@ -1,0 +1,24 @@
+"""Observability utilities (structured logging and manifests)."""
+
+from .logging import StructuredJsonFormatter, StructuredLoggerAdapter
+from .manifest import (
+    ArtifactSpec,
+    ManifestArtifact,
+    ManifestBuilder,
+    ManifestWriteResult,
+    PipelineManifest,
+    load_manifest,
+    validate_manifest,
+)
+
+__all__ = [
+    "ArtifactSpec",
+    "ManifestArtifact",
+    "ManifestBuilder",
+    "ManifestWriteResult",
+    "PipelineManifest",
+    "StructuredJsonFormatter",
+    "StructuredLoggerAdapter",
+    "load_manifest",
+    "validate_manifest",
+]

--- a/src/trading_system/observability/logging.py
+++ b/src/trading_system/observability/logging.py
@@ -1,0 +1,78 @@
+"""Structured logging utilities for trading-system pipelines."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+_LOG_DEFAULT_FIELDS: tuple[str, ...] = (
+    "name",
+    "msg",
+    "args",
+    "levelname",
+    "levelno",
+    "pathname",
+    "filename",
+    "module",
+    "exc_info",
+    "exc_text",
+    "stack_info",
+    "lineno",
+    "funcName",
+    "created",
+    "msecs",
+    "relativeCreated",
+    "thread",
+    "threadName",
+    "processName",
+    "process",
+)
+
+
+class StructuredJsonFormatter(logging.Formatter):
+    """Serialize log records as JSON payloads suitable for ingestion."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - override
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        extras = {
+            key: value
+            for key, value in record.__dict__.items()
+            if key not in _LOG_DEFAULT_FIELDS and not key.startswith("_")
+        }
+        if extras:
+            payload.update(extras)
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
+
+        return json.dumps(payload, sort_keys=True)
+
+
+class StructuredLoggerAdapter(logging.LoggerAdapter[logging.Logger]):
+    """Merge contextual metadata into structured log records."""
+
+    def process(
+        self, msg: str, kwargs: Mapping[str, Any] | None
+    ) -> tuple[str, dict[str, Any]]:
+        extra = dict(self.extra) if self.extra else {}
+        provided = dict((kwargs or {}).get("extra") or {})
+        extra.update(provided)
+        payload = dict(kwargs or {})
+        if extra:
+            payload["extra"] = extra
+        return msg, payload
+
+
+__all__ = ["StructuredJsonFormatter", "StructuredLoggerAdapter"]

--- a/src/trading_system/observability/manifest.py
+++ b/src/trading_system/observability/manifest.py
@@ -1,0 +1,401 @@
+"""Artifact manifest models and helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Literal
+
+import pyarrow.parquet as pq  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field
+
+MANIFEST_VERSION = "1.0.0"
+ArtifactKind = Literal["file", "directory", "missing"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactSpec:
+    """Lightweight descriptor for an artifact produced during a step."""
+
+    key: str
+    path: Path
+    kind: ArtifactKind | None = None
+    row_count: int | None = None
+    description: str | None = None
+
+
+@dataclass(slots=True)
+class _PendingStep:
+    name: str
+    status: str
+    started_at: datetime
+    completed_at: datetime
+    duration_seconds: float
+    details: str | None
+    artifacts: tuple[ArtifactSpec, ...]
+
+
+@dataclass(slots=True)
+class _PathMetadata:
+    kind: ArtifactKind
+    sha256: str | None
+    size_bytes: int | None
+    row_count: int | None
+
+
+class ManifestArtifact(BaseModel):
+    key: str
+    path: str
+    kind: ArtifactKind
+    sha256: str | None = None
+    size_bytes: int | None = None
+    row_count: int | None = Field(default=None, ge=0)
+    description: str | None = None
+
+
+class ManifestStep(BaseModel):
+    name: str
+    status: str
+    started_at: datetime
+    completed_at: datetime
+    duration_seconds: float = Field(ge=0)
+    details: str | None = None
+    artifacts: list[ManifestArtifact] = Field(default_factory=list)
+
+
+class ManifestRun(BaseModel):
+    pipeline: str
+    as_of: date
+    started_at: datetime
+    completed_at: datetime
+    duration_seconds: float = Field(ge=0)
+    success: bool
+    log_path: str | None = None
+    config_path: str | None = None
+    holdings_path: str | None = None
+    artifacts: list[ManifestArtifact] = Field(default_factory=list)
+
+
+class PipelineManifest(BaseModel):
+    version: str = Field(default=MANIFEST_VERSION)
+    run: ManifestRun
+    steps: list[ManifestStep] = Field(default_factory=list)
+
+
+@dataclass(slots=True)
+class ManifestWriteResult:
+    """Return value from :class:`ManifestBuilder` finalization."""
+
+    manifest: PipelineManifest
+    path: Path
+    summary: dict[str, str]
+
+
+class ManifestBuilder:
+    """Collect step metadata and materialize a manifest file."""
+
+    def __init__(
+        self,
+        *,
+        pipeline: str,
+        as_of: date,
+        reports_dir: Path,
+        config_path: Path | None,
+        holdings_path: Path | None,
+        log_path: Path | None,
+    ) -> None:
+        self._pipeline = pipeline
+        self._as_of = as_of
+        self._reports_dir = reports_dir
+        self._config_path = config_path
+        self._holdings_path = holdings_path
+        self._log_path = log_path
+        self._steps: list[_PendingStep] = []
+        self._globals: list[ArtifactSpec] = []
+        self._manifest_path = reports_dir / "manifest.json"
+        self._summary: dict[str, str] = {}
+        self._cache: dict[Path, _PathMetadata] = {}
+
+    def add_global_artifact(self, spec: ArtifactSpec) -> None:
+        self._globals.append(spec)
+        self._summary[spec.key] = str(spec.path)
+
+    def add_step(
+        self,
+        *,
+        name: str,
+        status: str,
+        started_at: datetime,
+        completed_at: datetime,
+        duration_seconds: float,
+        details: str | None,
+        artifacts: Sequence[ArtifactSpec],
+    ) -> None:
+        self._steps.append(
+            _PendingStep(
+                name=name,
+                status=status,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_seconds=duration_seconds,
+                details=details,
+                artifacts=tuple(artifacts),
+            )
+        )
+        for spec in artifacts:
+            self._summary.setdefault(spec.key, str(spec.path))
+
+    def finalize(
+        self,
+        *,
+        started_at: datetime,
+        completed_at: datetime,
+        success: bool,
+    ) -> ManifestWriteResult:
+        run_artifacts = [self._materialize(spec) for spec in self._run_specs()]
+        step_models: list[ManifestStep] = []
+        for step in self._steps:
+            step_models.append(
+                ManifestStep(
+                    name=step.name,
+                    status=step.status,
+                    started_at=step.started_at,
+                    completed_at=step.completed_at,
+                    duration_seconds=step.duration_seconds,
+                    details=step.details,
+                    artifacts=[self._materialize(spec) for spec in step.artifacts],
+                )
+            )
+
+        manifest = PipelineManifest(
+            run=ManifestRun(
+                pipeline=self._pipeline,
+                as_of=self._as_of,
+                started_at=started_at,
+                completed_at=completed_at,
+                duration_seconds=(completed_at - started_at).total_seconds(),
+                success=success,
+                log_path=str(self._log_path) if self._log_path else None,
+                config_path=str(self._config_path) if self._config_path else None,
+                holdings_path=str(self._holdings_path) if self._holdings_path else None,
+                artifacts=run_artifacts,
+            ),
+            steps=step_models,
+        )
+
+        text = manifest.model_dump_json(indent=2, by_alias=True)
+        self._manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        self._manifest_path.write_text(text, encoding="utf-8")
+
+        summary = self._summary.copy()
+        summary.setdefault("manifest_json", str(self._manifest_path))
+
+        return ManifestWriteResult(
+            manifest=manifest,
+            path=self._manifest_path,
+            summary=summary,
+        )
+
+    def _run_specs(self) -> Iterator[ArtifactSpec]:
+        if self._config_path is not None:
+            yield ArtifactSpec(key="config", path=self._config_path, kind="file")
+        if self._holdings_path is not None:
+            yield ArtifactSpec(key="holdings", path=self._holdings_path, kind="file")
+        if self._log_path is not None:
+            yield ArtifactSpec(key="run_log", path=self._log_path, kind="file")
+        yield from self._globals
+
+    def _materialize(self, spec: ArtifactSpec) -> ManifestArtifact:
+        path = spec.path
+        metadata = self._describe(path)
+        return ManifestArtifact(
+            key=spec.key,
+            path=str(path),
+            kind=metadata.kind,
+            sha256=metadata.sha256,
+            size_bytes=metadata.size_bytes,
+            row_count=metadata.row_count if spec.row_count is None else spec.row_count,
+            description=spec.description,
+        )
+
+    def _describe(self, path: Path) -> _PathMetadata:
+        if path in self._cache:
+            return self._cache[path]
+
+        if not path.exists():
+            metadata = _PathMetadata(
+                kind="missing",
+                sha256=None,
+                size_bytes=None,
+                row_count=None,
+            )
+        elif path.is_file():
+            file_hash, size, row_count = _hash_file(path)
+            metadata = _PathMetadata(
+                kind="file",
+                sha256=file_hash,
+                size_bytes=size,
+                row_count=row_count,
+            )
+        elif path.is_dir():
+            dir_hash, size, row_count = _hash_directory(path)
+            metadata = _PathMetadata(
+                kind="directory",
+                sha256=dir_hash,
+                size_bytes=size,
+                row_count=row_count,
+            )
+        else:
+            metadata = _PathMetadata(
+                kind="missing", sha256=None, size_bytes=None, row_count=None
+            )
+
+        self._cache[path] = metadata
+        return metadata
+
+
+def _hash_file(path: Path) -> tuple[str, int, int | None]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(131072), b""):
+            digest.update(chunk)
+            size += len(chunk)
+    row_count = _row_count_for_file(path)
+    return digest.hexdigest(), size, row_count
+
+
+def _hash_directory(path: Path) -> tuple[str, int, int | None]:
+    digest = hashlib.sha256()
+    total_size = 0
+    total_rows = 0
+    have_rows = False
+    for file_path in sorted(p for p in path.rglob("*") if p.is_file()):
+        rel = file_path.relative_to(path).as_posix().encode("utf-8")
+        file_hash, size, row_count = _hash_file(file_path)
+        digest.update(rel)
+        digest.update(b"|")
+        digest.update(file_hash.encode("utf-8"))
+        digest.update(b"|")
+        digest.update(str(size).encode("utf-8"))
+        total_size += size
+        if row_count is not None:
+            have_rows = True
+            total_rows += row_count
+    return digest.hexdigest(), total_size, total_rows if have_rows else None
+
+
+def _row_count_for_file(path: Path) -> int | None:
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
+        try:
+            parquet = pq.ParquetFile(path)
+        except Exception:  # pragma: no cover - defensive for partial files
+            return None
+        metadata = parquet.metadata
+        return metadata.num_rows if metadata is not None else None
+    if suffix in {".json", ".jsonl"}:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            return None
+        if isinstance(payload, list):
+            return len(payload)
+        if isinstance(payload, dict):
+            for key in ("alerts", "targets", "orders", "positions"):
+                value = payload.get(key)
+                if isinstance(value, list):
+                    return len(value)
+        return None
+    return None
+
+
+def load_manifest(path: Path) -> PipelineManifest:
+    """Load and validate a manifest JSON payload."""
+
+    content = path.read_text(encoding="utf-8")
+    data = json.loads(content)
+    return PipelineManifest.model_validate(data)
+
+
+def validate_manifest(manifest: PipelineManifest) -> list[str]:
+    """Recompute metadata and return human-readable mismatches."""
+
+    errors: list[str] = []
+    cache: dict[Path, _PathMetadata] = {}
+
+    def _validate_artifact(record: ManifestArtifact) -> None:
+        path = Path(record.path)
+        if path not in cache:
+            cache[path] = _collect_metadata(path)
+
+        meta = cache[path]
+        if record.kind != meta.kind:
+            errors.append(
+                f"{record.key}: expected kind {record.kind}, observed {meta.kind}"
+            )
+        if record.kind != "missing":
+            if record.sha256 and meta.sha256 and record.sha256 != meta.sha256:
+                errors.append(
+                    f"{record.key}: SHA mismatch {record.sha256} != {meta.sha256}"
+                )
+            if record.size_bytes is not None and meta.size_bytes is not None:
+                if record.size_bytes != meta.size_bytes:
+                    errors.append(
+                        f"{record.key}: size mismatch {record.size_bytes} != {meta.size_bytes}"
+                    )
+            if record.row_count is not None and meta.row_count is not None:
+                if record.row_count != meta.row_count:
+                    errors.append(
+                        f"{record.key}: row count mismatch {record.row_count} != {meta.row_count}"
+                    )
+            if not path.exists():
+                errors.append(f"{record.key}: path missing at {record.path}")
+
+    for artifact in manifest.run.artifacts:
+        _validate_artifact(artifact)
+    for step in manifest.steps:
+        for artifact in step.artifacts:
+            _validate_artifact(artifact)
+
+    return errors
+
+
+def _collect_metadata(path: Path) -> _PathMetadata:
+    if not path.exists():
+        return _PathMetadata(
+            kind="missing", sha256=None, size_bytes=None, row_count=None
+        )
+    if path.is_file():
+        file_hash, size, row_count = _hash_file(path)
+        return _PathMetadata(
+            kind="file", sha256=file_hash, size_bytes=size, row_count=row_count
+        )
+    if path.is_dir():
+        dir_hash, size, row_count = _hash_directory(path)
+        return _PathMetadata(
+            kind="directory",
+            sha256=dir_hash,
+            size_bytes=size,
+            row_count=row_count,
+        )
+    return _PathMetadata(kind="missing", sha256=None, size_bytes=None, row_count=None)
+
+
+__all__ = [
+    "ArtifactSpec",
+    "ManifestArtifact",
+    "ManifestBuilder",
+    "ManifestWriteResult",
+    "PipelineManifest",
+    "load_manifest",
+    "validate_manifest",
+]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,112 @@
+"""Tests for observability manifest helpers."""
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pandas as pd
+
+from trading_system.observability.manifest import (
+    ArtifactSpec,
+    ManifestBuilder,
+    load_manifest,
+    validate_manifest,
+)
+
+
+def test_manifest_builder_captures_artifacts(tmp_path: Path) -> None:
+    reports_dir = tmp_path / "reports" / "2024-05-02"
+    config_path = tmp_path / "config.yml"
+    config_path.write_text("config", encoding="utf-8")
+    holdings_path = tmp_path / "holdings.json"
+    holdings_path.write_text("{}", encoding="utf-8")
+    log_path = reports_dir / "run.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("log", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        pipeline="daily",
+        as_of=date(2024, 5, 2),
+        reports_dir=reports_dir,
+        config_path=config_path,
+        holdings_path=holdings_path,
+        log_path=log_path,
+    )
+
+    raw_dir = tmp_path / "data" / "raw" / "2024-05-02"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    frame = pd.DataFrame({"value": [1, 2, 3]})
+    raw_path = raw_dir / "sample.parquet"
+    frame.to_parquet(raw_path, index=False)
+
+    start = datetime.now(UTC)
+    builder.add_step(
+        name="data_pull",
+        status="completed",
+        started_at=start,
+        completed_at=start,
+        duration_seconds=0.0,
+        details=None,
+        artifacts=(ArtifactSpec(key="data_raw", path=raw_dir, kind="directory"),),
+    )
+
+    result = builder.finalize(
+        started_at=start,
+        completed_at=start,
+        success=True,
+    )
+
+    manifest = load_manifest(result.path)
+    assert any(
+        artifact.key == "data_raw"
+        for step in manifest.steps
+        for artifact in step.artifacts
+    )
+    assert manifest.run.log_path == str(log_path)
+    assert "manifest_json" in result.summary
+    assert validate_manifest(manifest) == []
+
+
+def test_validate_manifest_flags_hash_mismatch(tmp_path: Path) -> None:
+    reports_dir = tmp_path / "reports" / "2024-05-02"
+    config_path = tmp_path / "config.yml"
+    config_path.write_text("config", encoding="utf-8")
+    holdings_path = tmp_path / "holdings.json"
+    holdings_path.write_text("{}", encoding="utf-8")
+    log_path = reports_dir / "run.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("log", encoding="utf-8")
+
+    builder = ManifestBuilder(
+        pipeline="daily",
+        as_of=date(2024, 5, 2),
+        reports_dir=reports_dir,
+        config_path=config_path,
+        holdings_path=holdings_path,
+        log_path=log_path,
+    )
+
+    start = datetime.now(UTC)
+    artifact_path = reports_dir / "report.json"
+    artifact_path.write_text("{}", encoding="utf-8")
+
+    builder.add_step(
+        name="report_build",
+        status="completed",
+        started_at=start,
+        completed_at=start,
+        duration_seconds=0.0,
+        details=None,
+        artifacts=(ArtifactSpec(key="report_json", path=artifact_path, kind="file"),),
+    )
+
+    result = builder.finalize(
+        started_at=start,
+        completed_at=start,
+        success=True,
+    )
+
+    manifest = load_manifest(result.path)
+    log_path.write_text("corrupted", encoding="utf-8")
+
+    errors = validate_manifest(manifest)
+    assert any("run_log" in message for message in errors)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -311,14 +311,18 @@ def test_run_daily_pipeline_success(
         as_of=date(2024, 5, 2),
         holdings=holdings,
         holdings_path=holdings_path,
+        config_path=config_path,
         dry_run=True,
         force=False,
         channels=["email"],
+        log_path=None,
     )
 
     assert isinstance(summary, PipelineSummary)
     assert summary.success is True
     assert "report_json" in summary.manifest
+    manifest_path = Path(summary.manifest["manifest_json"])
+    assert manifest_path.is_file()
     assert any(step.name == "notify_send" for step in summary.steps)
 
 
@@ -338,9 +342,11 @@ def test_run_rebalance_pipeline_generates_proposal(
         as_of=date(2024, 5, 3),
         holdings=holdings,
         holdings_path=holdings_path,
+        config_path=config_path,
         dry_run=False,
         force=True,
         channels=["all"],
+        log_path=None,
     )
 
     assert summary.success is True
@@ -375,9 +381,11 @@ def test_pipeline_failure_propagates_step(
             as_of=date(2024, 5, 4),
             holdings=holdings,
             holdings_path=holdings_path,
+            config_path=config_path,
             dry_run=False,
             force=False,
             channels=["email"],
+            log_path=None,
         )
 
     error = excinfo.value


### PR DESCRIPTION
## Story
- [S-12: Observability and Artifact Manifest](docs/stories/S-12.md)

## Summary
- add an `observability` package that supplies structured JSON logging plus a manifest builder with artifact hashing, sizing, and row counting
- update pipeline orchestration to emit start/end events, accumulate manifest entries for each step, and persist `manifest.json` alongside pipeline outputs
- extend the CLI with observability commands for manifest validation and log tailing, pass config/log context into pipeline runs, and document the new workflows
- expand the automated suite with manifest unit tests and refreshed CLI/orchestrator coverage to assert the new behaviour

## Testing
- `poetry run fmt`
- `poetry run ci`

## Manual validation
- `poetry run ts run daily --config configs/sample-config.yml --holdings /tmp/holdings.json --asof 2024-05-02 --dry-run`
- `poetry run ts observability manifest --run configs/reports/2024-05-02`
- `poetry run ts observability tail --run configs/reports/2024-05-02`

## Checklist
- [x] Requirements in `docs/TECH_DESIGN_REQUIREMENTS.md` are satisfied
- [x] Workflow expectations in `docs/WORKFLOW.md` are satisfied
- [x] Story acceptance criteria met

------
https://chatgpt.com/codex/tasks/task_e_68d013f8db20832081f9c36c045bf771