### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aryeko/trading-system/security/code-scanning/1](https://github.com/aryeko/trading-system/security/code-scanning/1)

To resolve this issue, you should add an explicit `permissions:` block specifying the minimum access required by the workflow job. The standard minimal permissions for workflows that only lint, check, and test code (no pushes, repository writes, or PR modifications) is `contents: read`. This block can be placed at the workflow level (top-level, above `jobs:`) to apply to all jobs, or within the specific job (here, under `lint-and-test:`) if jobs might have different needs. Given only one job exists, placing it at the workflow root is simplest and clearest. The change requires only one addition to `.github/workflows/ci.yml`, right after the workflow name and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
