### PR TITLE
Document open source onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Trading System
+
+Thank you for your interest in improving Trading System! This guide walks you through the expectations for participating in the project.
+
+## Getting Started
+1. Fork the repository and clone your fork locally.
+2. Create a feature branch named `feature/my-change` (or similar) for your work.
+3. Keep your branch up to date with `main` to minimize merge conflicts.
+
+## Code Style
+- Format all Python code with **Black** (`poetry run fmt`).
+- Keep imports tidy and error-free with **Ruff**; no unused imports are allowed (`poetry run lint`).
+- Maintain complete and accurate type hints (`poetry run typecheck`).
+- Configure your editor or pre-commit hooks to run these checks automatically before committing.
+
+## Testing
+- Run the project test suite with `poetry run tests` before submitting a pull request.
+- Ensure coverage targets defined in the project settings are met.
+- Provide new or updated tests when you add features or fix bugs.
+- Use `poetry run ci` to mirror the continuous integration workflow when validating complex changes.
+
+## Commit Messages
+- Write commit messages in the imperative mood (e.g., `Fix bug in risk evaluation`).
+- Keep messages concise while explaining the change and its intent.
+- Separate unrelated work into distinct commits for clarity.
+
+## Pull Request Guidelines
+- Keep pull requests focused and as small as possible for easier review.
+- Reference related issues or GitHub Project cards in the description.
+- Include documentation and tests alongside new features or behavior changes.
+- Fill in the PR template completely so reviewers understand the context.
+
+## Project Management
+- Use the [GitHub Project board](https://github.com/users/aryeko/projects/2) to align your work with the roadmap and ongoing initiatives.
+- Consult the [project Wiki](https://github.com/aryeko/trading-system/wiki) for architecture, workflows, and design documentation before proposing changes.
+- Synchronize any documentation updates with `poetry run docs-sync` when relevant.
+
+## License Note
+By contributing to Trading System, you agree that your contributions will be licensed under the terms of the MIT License.

--- a/README.md
+++ b/README.md
@@ -1,114 +1,64 @@
 # Trading System
+*Automated portfolio operations to keep capital protected and opportunities in play.*
 
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![CI](https://github.com/aryeko/trading-system/actions/workflows/ci.yml/badge.svg)](https://github.com/aryeko/trading-system/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+![Python Version](https://img.shields.io/badge/Python-3.13-blue.svg)
+![Code Style: Black](https://img.shields.io/badge/Code%20Style-Black-000000.svg)
 
-Research and alerting toolkit for a mid/long-horizon discretionary trading workflow. The
-project follows the process and requirements described in [`docs/WORKFLOW.md`](docs/WORKFLOW.md)
-and [`docs/TECH_DESIGN_REQUIREMENTS.md`](docs/TECH_DESIGN_REQUIREMENTS.md).
+## Overview
+Guard portfolio capital daily. Propose improvements weekly/monthly.
 
-## Project Layout
+## Features
+- **Capital protection** with daily crash and drawdown checks.
+- **Portfolio reports** in HTML and JSON formats.
+- **Signals & rebalance proposals** for proactive adjustments.
+- **Backtests** to validate strategies before deployment.
+- **Point-in-time data** for reproducible analysis.
+- **CLI orchestration** to coordinate daily and scheduled runs.
+- **Notifications** through Slack and email channels.
 
+## Quickstart
+
+```bash
+git clone https://github.com/aryeko/trading-system
+cd trading-system
+poetry install
+
+poetry run ts run daily --config data/sample.yaml
 ```
-.
-├── configs/              # Environment, universe, and strategy configuration assets
-├── data/                 # Raw and curated market data (gitignored, see .gitkeep markers)
-│   ├── raw/
-│   └── curated/
-├── docs/                 # Design docs, requirements, and story backlog
-├── reports/              # Generated HTML/PDF reports (gitignored)
-├── scripts/              # Operational scripts and automation entry points
-├── src/trading_system/   # Application source code
-├── stories/              # Convenience pointers back to docs/stories
-└── tests/                # Pytest suite
+
+## Usage Examples
+
+```bash
+# Evaluate portfolio risk with point-in-time context
+poetry run ts risk evaluate --config data/sample.yaml --holdings data/holdings.json
+
+# Execute the full daily pipeline with rebalance proposals
+poetry run ts run rebalance --config data/sample.yaml --holdings data/holdings.json
+
+# Run a historical backtest across a custom period
+poetry run ts backtest run --config data/sample.yaml --start 2024-01-01 --end 2024-06-30 --output reports/backtests/demo
 ```
 
-## Getting Started
+## Documentation
+Comprehensive setup guides, operational workflows, and configuration references live in the [Wiki](https://github.com/aryeko/trading-system/wiki).
 
-1. Install dependencies using Poetry (Python 3.13+ required):
-   ```bash
-   poetry install
-   ```
-2. Activate the in-project virtual environment:
-   ```bash
-   source .venv/bin/activate
-   ```
-3. Run the command line interface:
-   ```bash
-   poetry run ts --help
-   ```
-4. Execute the automated tests:
-   ```bash
-   poetry run tests
-   ```
+## Roadmap
+- ✅ Daily capital protection checks
+- ✅ Automated HTML/JSON reporting
+- ✅ CLI orchestration workflows
+- 🔲 Expanded broker integrations
+- 🔲 Enhanced scenario backtesting library
+- 🔲 Additional notification channels and templates
 
-## CLI Highlights
+Track ongoing initiatives on the [GitHub Project board](https://github.com/users/aryeko/projects/2).
 
-Commands default the as-of option (pass via `--asof`/`--as-of` or `TS_ASOF`) to today's date, so you can omit it for
-"run it now" workflows.
-
-- `poetry run ts signals build --config configs/sample-config.yml --as-of YYYY-MM-DD`
-  generates a `signals.parquet` artifact with rule outcomes and rank scores.
-- `poetry run ts signals explain --config configs/sample-config.yml --symbol AAPL --as-of YYYY-MM-DD`
-  prints the entry/exit evaluation details and key indicator values for a symbol.
-- `poetry run ts risk evaluate --config configs/sample-config.yml --holdings data/holdings.json --as-of YYYY-MM-DD`
-  emits `risk_alerts.json` summarizing crash/drawdown alerts and market filter state.
-- `poetry run ts risk explain --config configs/sample-config.yml --holdings data/holdings.json --symbol AAPL --as-of YYYY-MM-DD`
-  surfaces detailed metrics supporting each alert for the selected holding.
-- `poetry run ts report build --config configs/sample-config.yml --holdings data/holdings.json --as-of YYYY-MM-DD`
-  compiles HTML/JSON daily operator reports (add `--include-pdf` to request PDF output).
-- `poetry run ts report preview --config configs/sample-config.yml --holdings data/holdings.json --as-of YYYY-MM-DD --open`
-  regenerates the report and optionally opens the HTML for manual QA.
-- `poetry run ts notify preview --config configs/sample-config.yml --as-of YYYY-MM-DD --channel slack`
-  prints the Slack payload for the existing daily report without sending it.
-- `poetry run ts notify send --config configs/sample-config.yml --as-of YYYY-MM-DD --channel all`
-  delivers email and Slack notifications (use `--dry-run` to render without sending).
-- `poetry run ts steps`
-  enumerates the pipeline stages with artifact expectations.
-- `poetry run ts run daily --config configs/sample-config.yml --holdings data/holdings.json --asof YYYY-MM-DD`
-  orchestrates pull → preprocess → risk → report → notify with structured logging.
-- `poetry run ts run rebalance --config configs/sample-config.yml --holdings data/holdings.json --asof YYYY-MM-DD --force`
-  runs the full pipeline including signals/rebalance even when cadence is overriden.
-- `poetry run ts observability manifest --run reports/YYYY-MM-DD`
-  validates artifact hashes, sizes, and row counts while printing a summary table.
-- `poetry run ts observability tail --run reports/YYYY-MM-DD`
-  streams the structured JSON logs captured during the pipeline run.
-- `poetry run ts backtest run --config configs/sample-config.yml --start YYYY-MM-DD --end YYYY-MM-DD --output reports/backtests/demo --label smoke`
-  executes the deterministic backtest engine and writes metrics, equity curve, trade log, and optional Plotly HTML chart.
-- `poetry run ts backtest compare --baseline reports/backtests/base --candidate reports/backtests/experiment`
-  highlights metric deltas across backtest scenarios.
-
-### Handy Automation Commands
-
-All local automation lives under Poetry scripts:
-
-- `poetry run lint` — Ruff lint + Black check
-- `poetry run fmt` — apply Black formatting
-- `poetry run typecheck` — mypy static analysis
-- `poetry run tests` — pytest suite
-- `poetry run ci` — run lint, typecheck, and tests sequentially
-
-## Tooling
-
-- Formatting: `black`
-- Linting: `ruff`
-- Static typing: `mypy`
-- Testing: `pytest` & `pytest-cov`
-
-CI workflows execute the same toolchain to keep `main` green.
-
-### Notification Setup
-
-Email delivery expects the following environment variables:
-
-- `TS_EMAIL_SENDER` — From address used in the outgoing message.
-- `TS_SMTP_HOST` — SMTP server hostname.
-- `TS_SMTP_PORT` — SMTP port (default 587).
-- `TS_SMTP_USERNAME`/`TS_SMTP_PASSWORD` — Optional credentials for authenticated servers.
-- `TS_SMTP_STARTTLS` — Set to `false` to disable STARTTLS (enabled by default).
-
-Slack notifications require `config.notify.slack_webhook` to point at an incoming webhook URL. Run
-`poetry run ts notify send --dry-run ...` during setup to validate formatting without hitting external services.
+## Contributing
+We welcome collaboration! Please review [CONTRIBUTING.md](CONTRIBUTING.md) before opening an issue or pull request.
 
 ## License
+Released under the [MIT License](LICENSE).
 
-Released under the MIT License. See [LICENSE](./LICENSE) for details.
+## Acknowledgements
+- Built with a focus on operator experience and repeatable portfolio governance.


### PR DESCRIPTION
## Summary
- rewrite the README with a production-ready structure that highlights key features, quickstart commands, and roadmap links
- add a contributor guide covering workflow expectations, code style, testing, and project management resources
- update roadmap references and contributor commands to match the current project board and Poetry tooling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d31c6c443c8320839d7d966ce0e420